### PR TITLE
Test js-controller with the local DB versions

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -39,7 +39,7 @@ jobs:
 
   # ===================
 
-  # Runs unit tests on all supported node versions and OSes
+  # Runs unit tests on all supported combinations of node versions, OSes and JS-Controller
   unit-tests:
     if: contains(github.event.head_commit.message, '[skip ci]') == false
 
@@ -50,6 +50,7 @@ jobs:
       matrix:
         node-version: [10.x, 12.x, 14.x]
         os: [ubuntu-latest, windows-latest, macos-latest]
+        js-controller: [master] # git branches/commits/tags to test against
 
     steps:
     - name: Checkout code
@@ -61,9 +62,27 @@ jobs:
         node-version: ${{ matrix.node-version }}
 
     - name: Install dependencies
-      run: npm ci
+      run: |
+        npm ci
+        npm i -g lerna
+        lerna exec -- npm link
 
-    - name: Run component tests
+    - name: Clone JS-Controller
+      run: |
+        git clone https://github.com/ioBroker/ioBroker.js-controller
+        cd ioBroker.js-controller
+        git checkout ${{ matrix.js-controller }}
+    
+    - name: Install JS-Controller's dependencies
+      # TODO: Determine the DB-dependencies automatically
+      run: |
+        npm i
+        npm link @iobroker/db-objects-file
+        npm link @iobroker/db-objects-redis
+        npm link @iobroker/db-states-file
+        npm link @iobroker/db-states-redis
+
+    - name: Run JS-Controller's tests
       run: npm run test
       env:
         CI: true

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-18.04, windows-latest, macos-latest]
         js-controller: [master] # git branches/commits/tags to test against
 
     steps:

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -83,12 +83,43 @@ jobs:
         npm link @iobroker/db-states-file
         npm link @iobroker/db-states-redis
 
+    # JS-Controller tests need Redis to be installed
+    - name: Install Redis (Linux)
+      if: ${{ matrix.os == 'ubuntu-18.04' }}
+      run: |
+        sudo add-apt-repository ppa:chris-lea/redis-server -y
+        sudo apt-get update -q
+        sudo apt-get install redis-server redis-sentinel -y
+        sudo systemctl start redis-server
+    - name: Install Redis (MacOS)
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: |
+        brew update
+        brew install redis
+        ln -sfv /usr/local/opt/redis/*.plist ~/Library/LaunchAgents
+        launchctl load ~/Library/LaunchAgents/homebrew.mxcl.redis.plist
+    - name: Install Redis (Windows)
+      if: ${{ matrix.os == 'windows-latest' }}
+      run: |
+        choco install redis-64 --version 3.0.503
+        powershell "Start-Process redis-server.exe -PassThru"
+
     - name: Run JS-Controller's tests
       run: |
         cd ioBroker.js-controller
         npm run test
       env:
         CI: true
+
+    - name: Run JS-Controller's Redis Sentinel Tests (Linux)
+      if: ${{ matrix.os == 'ubuntu-18.04' }}
+      run: |
+        cd ioBroker.js-controller
+        sudo chmod ogu+x test/redis-socket/setup-socket.sh
+        sudo chmod ogu+x test/redis-sentinel/*.sh
+        test/redis-socket/setup-socket.sh
+        cd test/redis-sentinel
+        ./test-sentinel.sh
 
   # ===================
 

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -49,7 +49,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x, 14.x]
-        os: [ubuntu-18.04, windows-latest, macos-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         js-controller: [master] # git branches/commits/tags to test against
 
     steps:
@@ -85,7 +85,7 @@ jobs:
 
     # JS-Controller tests need Redis to be installed
     - name: Install Redis (Linux)
-      if: ${{ matrix.os == 'ubuntu-18.04' }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         sudo add-apt-repository ppa:chris-lea/redis-server -y
         sudo apt-get update -q
@@ -112,7 +112,7 @@ jobs:
         CI: true
 
     - name: Run JS-Controller's Redis Sentinel Tests (Linux)
-      if: ${{ matrix.os == 'ubuntu-18.04' }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: |
         cd ioBroker.js-controller
         sudo chmod ogu+x test/redis-socket/setup-socket.sh

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -63,6 +63,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        pwd
         npm ci
         npm i -g lerna
         lerna exec -- npm link
@@ -76,6 +77,7 @@ jobs:
     - name: Install JS-Controller's dependencies
       # TODO: Determine the DB-dependencies automatically
       run: |
+        pwd
         npm i
         npm link @iobroker/db-objects-file
         npm link @iobroker/db-objects-redis
@@ -83,7 +85,9 @@ jobs:
         npm link @iobroker/db-states-redis
 
     - name: Run JS-Controller's tests
-      run: npm run test
+      run: |
+        pwd
+        npm run test
       env:
         CI: true
 

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -63,7 +63,6 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pwd
         npm ci
         npm i -g lerna
         lerna exec -- npm link
@@ -77,7 +76,7 @@ jobs:
     - name: Install JS-Controller's dependencies
       # TODO: Determine the DB-dependencies automatically
       run: |
-        pwd
+        cd ioBroker.js-controller
         npm i
         npm link @iobroker/db-objects-file
         npm link @iobroker/db-objects-redis
@@ -86,7 +85,7 @@ jobs:
 
     - name: Run JS-Controller's tests
       run: |
-        pwd
+        cd ioBroker.js-controller
         npm run test
       env:
         CI: true


### PR DESCRIPTION
With this PR, we pull the specified JS-Controller versions from Github and run the tests there.

I expect this will require a few iterations, so we should probably squash-merge later.