### PR TITLE
Clearly separate Client and Server classes and offer Backward compatibility

### DIFF
--- a/packages/db-base/lib/inMemFileDB.js
+++ b/packages/db-base/lib/inMemFileDB.js
@@ -349,7 +349,7 @@ class InMemoryFileDB {
     }
 
     // Destructor of the class. Called by shutting down.
-    destroy() {
+    async destroy() {
         this.stateTimer && this.saveState();
     }
 }

--- a/packages/db-base/lib/redisHandler.js
+++ b/packages/db-base/lib/redisHandler.js
@@ -167,7 +167,7 @@ class RedisHandler extends EventEmitter {
         if (responseId === null) {
             if (this.options.enhancedLogging) {
                 this.log.silly(this.socketId + ' Redis response DIRECT: ' + data.toString().replace(/[\r\n]+/g, ''));
-            } // TODO remove data logging (performance)
+            }
             return this._write(data);
         }
         if (!responseId) {

--- a/packages/db-objects-file/index.js
+++ b/packages/db-objects-file/index.js
@@ -1,6 +1,6 @@
 module.exports = {
     Client: require('@iobroker/db-objects-redis').Client,
-    Server: require('./lib/objects/objectsInMemServerRedis.js'),
+    Server: require('./lib/objects/objectsInMemServerClass.js'),
     getDefaultObjectsPort: _host => {
         return 9001;
     }

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -499,8 +499,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         id   = _path.id;
         name = _path.name;
 
-        let changed = false;
-
         this._loadFileSettings(id);
 
         const location = path.join(this.objectsDir, id, name);

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -503,13 +503,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
         this._loadFileSettings(id);
 
-        if (this.fileOptions[id][name]) {
-            changed = true;
-            delete this.fileOptions[id][name];
-        }
-        if (this.files[id] && this.files[id][name]) {
-            delete this.files[id][name];
-        }
         const location = path.join(this.objectsDir, id, name);
         if (fs.existsSync(location)) {
             const stat = fs.statSync(location);
@@ -537,10 +530,16 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         } else {
             throw new Error(utils.ERRORS.ERROR_NOT_FOUND);
         }
-        // Store dir description
-        if (changed) {
-            this._saveFileSettings(id, true);
+
+        if (this.fileOptions[id][name]) {
+            delete this.fileOptions[id][name];
         }
+        if (this.files[id] && this.files[id][name]) {
+            delete this.files[id][name];
+        }
+
+        // Store dir description
+        this._saveFileSettings(id, true);
     }
 
     // needed by server
@@ -580,6 +579,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 }
             }
         }
+        this.log.debug('fileOptions: ' + JSON.stringify(_files));
 
         const location = path.join(this.objectsDir, id, name);
         if (fs.existsSync(location)) {
@@ -590,6 +590,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 }
                 if (dirFiles[i] !== '_data.json' && _files.indexOf(dirFiles[i]) === -1) {
                     _files.push(dirFiles[i]);
+                    this.log.debug('Add: ' + dirFiles[i]);
                 }
             }
         } else {

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -70,13 +70,13 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // internal functionality
-    normalizeFilename(name) {
+    _normalizeFilename(name) {
         return name ? name.replace(/[/\\]+/g, '/') : name;
     }
 
     // -------------- FILE FUNCTIONS -------------------------------------------
     // internal functionality
-    saveFileSettings(id, force) {
+    _saveFileSettings(id, force) {
         if (typeof id === 'boolean') {
             force = id;
             id = undefined;
@@ -118,7 +118,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // internal functionality
-    loadFileSettings(id) {
+    _loadFileSettings(id) {
         if (!this.fileOptions[id]) {
             const location = path.join(this.objectsDir, id, '_data.json');
             if (fs.existsSync(location)) {
@@ -130,7 +130,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 }
                 let corrected = false;
                 Object.keys(this.fileOptions[id]).forEach(filename => {
-                    const normalized = this.normalizeFilename(filename);
+                    const normalized = this._normalizeFilename(filename);
                     if (normalized !== filename) {
                         const options = this.fileOptions[id][filename];
                         delete this.fileOptions[id][filename];
@@ -177,7 +177,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             return results;
         }
 
-        this.getObjectView('system', 'meta', null, (err, res) => {
+        this._getObjectView('system', 'meta', null, (err, res) => {
             if (err) {
                 return typeof callback === 'function' && callback(err);
             }
@@ -216,7 +216,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                         resNotifies.push('Ignoring Directory "' + dir + '" because officially not created as meta object. Please remove directory!');
                         return;
                     }
-                    this.loadFileSettings(dir);
+                    this._loadFileSettings(dir);
                     const files = getAllFiles(dirPath);
                     files.forEach(file => {
                         const localFile = file.substr(dirPath.length + 1);
@@ -244,7 +244,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                             dirSynced++;
                         }
                     });
-                    this.saveFileSettings(dir);
+                    this._saveFileSettings(dir);
                     resSynced += dirSynced;
                     dirSynced && resNotifies.push('Added ' + dirSynced + ' Files in Directory "' + dir + '"');
                 });
@@ -257,7 +257,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    async writeFile(id, name, data, options, callback) {
+    async _writeFile(id, name, data, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -279,7 +279,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         options = options || {};
 
         try {
-            this.loadFileSettings(id);
+            this._loadFileSettings(id);
 
             this.files[id] = this.files[id] || {};
 
@@ -327,7 +327,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 }
 
                 // Store dir description
-                this.saveFileSettings(id);
+                this._saveFileSettings(id);
             } catch (e) {
                 this.log.error(this.namespace + ' Cannot write files: ' + path.join(this.objectsDir, id, name) + ': ' + e.message);
                 return tools.maybeCallbackWithError(callback, e);
@@ -339,7 +339,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    async readFile(id, name, options, callback) {
+    async _readFile(id, name, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options  = null;
@@ -357,7 +357,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
         options = options || {};
         try {
-            this.loadFileSettings(id);
+            this._loadFileSettings(id);
 
             this.files[id] = this.files[id] || {};
 
@@ -443,7 +443,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
      * @return {Promise<boolean>}
      */
     // needed by server
-    async objectExists(id, _options) {
+    async _objectExists(id, _options) {
         if (!id || typeof id !== 'string') {
             return Promise.reject(new Error(`invalid id ${JSON.stringify(id)}`));
         }
@@ -466,7 +466,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
      * @returns {Promise<boolean>}
      */
     // needed by server
-    async fileExists(id, name, _options) {
+    async _fileExists(id, name, _options) {
         if (typeof name !== 'string') {
             name = '';
         }
@@ -514,7 +514,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    unlink(id, name, options, callback) {
+    _unlink(id, name, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options  = null;
@@ -529,7 +529,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         try {
             let changed = false;
 
-            this.loadFileSettings(id);
+            this._loadFileSettings(id);
 
             if (this.fileOptions[id][name]) {
                 changed = true;
@@ -548,7 +548,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     let cnt = 0;
                     for (let f = 0; f < fdir.length; f++) {
                         cnt++;
-                        this.unlink(id, name + '/' + fdir[f], options, err => {
+                        this._unlink(id, name + '/' + fdir[f], options, err => {
                             if (!--cnt) {
                                 this.log.debug('Delete directory ' + path.join(id, name));
                                 try {
@@ -583,7 +583,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             }
             // Store dir description
             if (changed) {
-                this.saveFileSettings(id);
+                this._saveFileSettings(id);
             }
         } catch (e) {
             return tools.maybeCallbackWithError(callback, e);
@@ -591,7 +591,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    async readDir(id, name, options, callback) {
+    async _readDir(id, name, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -625,7 +625,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             name += '/';
         }
 
-        this.loadFileSettings(id);
+        this._loadFileSettings(id);
 
         const len = (name) ? name.length : 0;
         for (const f of Object.keys(this.fileOptions[id])) {
@@ -741,7 +741,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    rename(id, oldName, newName, options, callback) {
+    _rename(id, oldName, newName, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -757,7 +757,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
 
         try {
-            this.loadFileSettings(id);
+            this._loadFileSettings(id);
 
             const location = path.join(this.objectsDir, id, '_data.json');
             Object.keys(this.fileOptions[id]).forEach(name => {
@@ -787,7 +787,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // internal functionality
-    clone(obj) {
+    _clone(obj) {
         if (obj === null || obj === undefined || !tools.isObject(obj)) {
             return obj;
         }
@@ -795,13 +795,13 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         const temp = obj.constructor(); // changed
 
         for (const key of Object.keys(obj)) {
-            temp[key] = this.clone(obj[key]);
+            temp[key] = this._clone(obj[key]);
         }
         return temp;
     }
 
     // needed by server
-    subscribeConfigForClient(client, pattern, options, callback) {
+    _subscribeConfigForClient(client, pattern, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -813,7 +813,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    unsubscribeConfigForClient(client, pattern, options, callback) {
+    _unsubscribeConfigForClient(client, pattern, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -825,7 +825,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    getObject(id, options, callback) {
+    _getObject(id, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -835,7 +835,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    getKeys(pattern, options, callback, _dontModify) {
+    _getKeys(pattern, options, callback, _dontModify) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -857,7 +857,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    getObjects(keys, options, callback, _dontModify) {
+    _getObjects(keys, options, callback, _dontModify) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -900,7 +900,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    delObject(id, options, callback) {
+    _delObject(id, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -988,7 +988,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    getObjectView(design, search, params, options, callback) {
+    _getObjectView(design, search, params, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
@@ -1011,19 +1011,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
     }
 
-    // special functionality
-    _destroyDB(_options, callback) {
-        if (fs.existsSync(this.datasetName)) {
-            fs.unlinkSync(this.datasetName);
-        }
-
-        // also delete user files
-        if (fs.existsSync(this.objectsDir)) {
-            fs.emptyDirSync(this.objectsDir);
-        }
-
-        typeof callback === 'function' && setImmediate(() => callback());
-    }
     // special functionality
     destroyDB(options, callback) {
         if (typeof options === 'function') {
@@ -1054,7 +1041,16 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 if (!options.acl.file.write || options.user !== utils.CONSTS.SYSTEM_ADMIN_USER) {
                     typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
                 } else {
-                    return this._destroyDB(options, callback);
+                    if (fs.existsSync(this.datasetName)) {
+                        fs.unlinkSync(this.datasetName);
+                    }
+
+                    // also delete user files
+                    if (fs.existsSync(this.objectsDir)) {
+                        fs.emptyDirSync(this.objectsDir);
+                    }
+
+                    typeof callback === 'function' && setImmediate(() => callback());
                 }
             }
         });
@@ -1064,7 +1060,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     destroy() {
         super.destroy();
 
-        this.saveFileSettings(true);
+        this._saveFileSettings(true);
         if (this.stateTimer) {
             clearTimeout(this.stateTimer);
             this.stateTimer = null;

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -102,13 +102,14 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
     }
 
-    /**
+    /*/**
      * Checks if given Id is a meta object, else throws error
      *
      * @param {string} id to check
      * @throws Error if id is invalid
      */
-    // check later
+    // check later, remove
+    /*
     async validateMetaObject(id) {
         if (this.existingMetaObjects[id] === undefined) {
             // if not cached -> getObject
@@ -122,7 +123,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         } else if (this.existingMetaObjects[id] === false) {
             return Promise.reject(new Error(`${id} is not an object of type "meta"`));
         }
-    }
+    }*/
 
     // internal functionality
     normalizeFilename(name) {
@@ -207,7 +208,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // check later
-    checkFile(id, name, options, flag, callback) {
+    /*checkFile(id, name, options, flag, callback) {
         this.loadFileSettings(id);
 
         const acl = this.fileOptions[id][name] || {};
@@ -217,12 +218,12 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         } else {
             return callback && callback(true, options);
         }
-    }
+    }*/
 
     // needed by server, check later
-    checkFileRights(id, name, options, flag, callback) {
+    /*checkFileRights(id, name, options, flag, callback) {
         return utils.checkFileRights(this, id, name, options, flag, callback);
-    }
+    }*/
 
     /*
     setDefaultAcl(callback) {
@@ -259,12 +260,12 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }*/
 
     // check later
-    getUserGroup(user, callback) {
+    /*getUserGroup(user, callback) {
         return utils.getUserGroup(this, user, (error, user, userGroups, userAcl) => {
             error && this.log.error(`${this.namespace} ${error}`);
             callback(user, userGroups, userAcl);
         });
-    }
+    }*/
 
     /*
     insert(id, attName, ignore, options, obj, callback) {
@@ -446,7 +447,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         if (options && options.acl) {
             options.acl = null;
         }
-        if (!callback) {
+        /*if (!callback) {
             return new Promise((resolve, reject) => {
                 this.writeFile(id, name, data, options, (err, res, mimeType) => {
                     if (!err) {
@@ -456,14 +457,14 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 });
             });
-        }
+        }*/
 
-        try {
+        /*try {
             await this.validateMetaObject(id);
         } catch (e) {
             this.log.error(`Cannot write file ${name}: ${e.message}`);
             return tools.maybeCallbackWithError(callback, e);
-        }
+        }*/
 
         const _path = utils.sanitizePath(id, name, callback);
         if (!_path) {
@@ -478,13 +479,13 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             this.files[id] = this.files[id] || {};
 
             // If file yet exists => check the permissions
-            return this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-                if (err) {
-                    return tools.maybeCallbackWithError(callback, err);
-                } else {
-                    return this._writeFile(id, name, data, options, callback);
-                }
-            });
+            //return this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
+            //    if (err) {
+            //        return tools.maybeCallbackWithError(callback, err);
+            //    } else {
+            return this._writeFile(id, name, data, options, callback);
+            //    }
+            //});
         } catch (e) {
             return tools.maybeCallbackWithError(callback, e);
         }
@@ -580,7 +581,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             options.acl = null;
         }
 
-        if (!callback) {
+        /*if (!callback) {
             return new Promise((resolve, reject) => {
                 this.readFile(id, name, options, (err, res, mimeType) =>{
                     if (!err) {
@@ -590,7 +591,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 });
             });
-        }
+        }*/
 
         const _path = utils.sanitizePath(id, name, callback);
         if (!_path) {
@@ -599,30 +600,30 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         id = _path.id;
         name = _path.name;
 
-        this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                return this._readFile(id, name, options, callback);
-            }
-        });
+        //this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, (err, options) => {
+        //    if (err) {
+        //        typeof callback === 'function' && setImmediate(() => callback(err));
+        //    } else {
+        return this._readFile(id, name, options, callback);
+        //    }
+        //});
     }
 
     /**
      * Check if given object exists
      *
      * @param {string} id id of the object
-     * @param {object} [options] optional user context
+     * @param {object} [_options] optional user context
      * @return {Promise<boolean>}
      */
     // needed by server
-    async objectExists(id, options) {
+    async objectExists(id, _options) {
         if (!id || typeof id !== 'string') {
             return Promise.reject(new Error(`invalid id ${JSON.stringify(id)}`));
         }
 
         try {
-            await new Promise((resolve, reject) => {
+            /*await new Promise((resolve, reject) => {
                 utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, err => {
                     if (err) {
                         reject(err);
@@ -630,7 +631,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                         resolve();
                     }
                 });
-            });
+            });*/
             // check if the id exists
             return Object.prototype.hasOwnProperty.call(this.dataset, id);
         } catch (e) {
@@ -644,11 +645,11 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
      *
      * @param {string} id id of the namespace
      * @param {string} [name] name of the file
-     * @param {object} [options] optional user context
+     * @param {object} [_options] optional user context
      * @returns {Promise<boolean>}
      */
     // needed by server
-    async fileExists(id, name, options) {
+    async fileExists(id, name, _options) {
         if (typeof name !== 'string') {
             name = '';
         }
@@ -656,7 +657,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         const location = path.join(this.objectsDir, id, name);
 
         try {
-            await new Promise((resolve, reject) => {
+            /*await new Promise((resolve, reject) => {
                 this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, err => {
                     if (err) {
                         reject(err);
@@ -665,6 +666,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 });
             });
+            */
             const stat = await fs.promises.lstat(location);
             return Promise.resolve(stat.isFile());
         } catch (e) {
@@ -681,11 +683,11 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
      *
      * @param {string} id id of the namespace
      * @param {string} [name] name of the directory
-     * @param {object} [options] optional user context
+     * @param {object} [_options] optional user context
      * @returns {Promise<boolean>}
      */
     // special functionality Server
-    async dirExists(id, name, options) {
+    async dirExists(id, name, _options) {
         if (typeof name !== 'string') {
             name = '';
         }
@@ -693,7 +695,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         const location = path.join(this.objectsDir, id, name);
 
         try {
-            await new Promise((resolve, reject) => {
+            /*await new Promise((resolve, reject) => {
                 this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, err => {
                     if (err) {
                         reject(err);
@@ -701,7 +703,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                         resolve();
                     }
                 });
-            });
+            });*/
             const stat = await fs.promises.lstat(location);
             return Promise.resolve(stat.isDirectory());
         } catch (e) {
@@ -794,17 +796,17 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         id   = _path.id;
         name = _path.name;
 
-        this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                if (!options.acl.file['delete']) {
-                    typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-                } else {
-                    return this._unlink(id, name, options, callback);
-                }
-            }
-        });
+        //this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
+        //    if (err) {
+        //        typeof callback === 'function' && setImmediate(() => callback(err));
+        //    } else {
+        //        if (!options.acl.file['delete']) {
+        //            typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
+        //        } else {
+        return this._unlink(id, name, options, callback);
+        //        }
+        //    }
+        //});
     }
 
     /*
@@ -958,17 +960,17 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             name = _path.name;
         }
 
-        this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                if (!options.acl.file.list) {
-                    typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-                } else {
-                    return this._readDir(id, name, options, callback);
-                }
-            }
-        });
+        //this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, (err, options) => {
+        //    if (err) {
+        //        typeof callback === 'function' && setImmediate(() => callback(err));
+        //    } else {
+        //        if (!options.acl.file.list) {
+        //            typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
+        //        } else {
+        return this._readDir(id, name, options, callback);
+        //        }
+        //    }
+        //});
     }
 
     // needed by server
@@ -1022,17 +1024,17 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             newName = newName.substring(1);
         }
 
-        this.checkFileRights(id, oldName, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                if (!options.acl.file.write) {
-                    typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-                } else {
-                    return this._rename(id, oldName, newName, options, callback);
-                }
-            }
-        });
+        //this.checkFileRights(id, oldName, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
+        //    if (err) {
+        //        typeof callback === 'function' && setImmediate(() => callback(err));
+        //    } else {
+        //        if (!options.acl.file.write) {
+        //            typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
+        //        } else {
+        return this._rename(id, oldName, newName, options, callback);
+        //        }
+        //    }
+        //});
     }
 
     /*
@@ -1543,13 +1545,13 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             options = null;
         }
 
-        utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                return this._subscribeConfigForClient(client, pattern, options, callback);
-            }
-        });
+        //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
+        //    if (err) {
+        //        typeof callback === 'function' && setImmediate(() => callback(err));
+        //    } else {
+        return this._subscribeConfigForClient(client, pattern, options, callback);
+        //    }
+        //});
     }
 
     /*
@@ -1575,13 +1577,13 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             options = null;
         }
 
-        utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                return this._unsubscribeConfigForClient(client, pattern, options, callback);
-            }
-        });
+        //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
+        //    if (err) {
+        //        typeof callback === 'function' && setImmediate(() => callback(err));
+        //    } else {
+        return this._unsubscribeConfigForClient(client, pattern, options, callback);
+        //    }
+        //});
 
     }
 
@@ -1754,7 +1756,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             callback = options;
             options = null;
         }
-        if (!callback) {
+        /*if (!callback) {
             return new Promise((resolve, reject) => {
                 this.getObject(id, options, (err, obj) => {
                     if (err) {
@@ -1764,24 +1766,24 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 });
             });
-        }
+        }*/
 
         if (typeof callback === 'function') {
             if (options && options.acl) {
                 options.acl = null;
             }
-            utils.checkObjectRights(this, id, this.dataset[id], options, utils.CONSTS.ACCESS_READ, (err, options) => {
-                if (err) {
-                    return tools.maybeCallbackWithError(callback, err);
-                } else {
-                    return this._getObject(id, options, callback);
-                }
-            });
+            //utils.checkObjectRights(this, id, this.dataset[id], options, utils.CONSTS.ACCESS_READ, (err, options) => {
+            //    if (err) {
+            //        return tools.maybeCallbackWithError(callback, err);
+            //    } else {
+            return this._getObject(id, options, callback);
+            //    }
+            //});
         }
     }
 
     // check later
-    getObjectAsync(id, options) {
+    /*getObjectAsync(id, options) {
         return new Promise((resolve, reject) => {
             this.getObject(id, options, (err, obj) => {
                 if (err) {
@@ -1791,7 +1793,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 }
             });
         });
-    }
+    }*/
 
     // needed by server
     _getKeys(pattern, options, callback, _dontModify) {
@@ -1812,7 +1814,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             options = null;
         }
 
-        if (!callback) {
+        /*if (!callback) {
             return new Promise((resolve, reject) => {
                 this.getKeys(pattern, options, (err, obj) => {
                     if (err) {
@@ -1822,18 +1824,18 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 }, dontModify);
             });
-        }
+        }*/
 
         if (options && options.acl) {
             options.acl = null;
         }
-        utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                return this._getKeys(pattern, options, callback, dontModify);
-            }
-        });
+        //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
+        //    if (err) {
+        //        typeof callback === 'function' && setImmediate(() => callback(err));
+        //    } else {
+        return this._getKeys(pattern, options, callback, dontModify);
+        //    }
+        //});
     }
 
     /*
@@ -1853,11 +1855,11 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
         const result = [];
         for (let i = 0; i < keys.length; i++) {
-            if (utils.checkObject(this.dataset[keys[i]], options, utils.CONSTS.ACCESS_READ)) {
-                result.push(this.clone(this.dataset[keys[i]]));
-            } else {
-                result.push({error: utils.ERRORS.ERROR_PERMISSION});
-            }
+            //if (utils.checkObject(this.dataset[keys[i]], options, utils.CONSTS.ACCESS_READ)) {
+            result.push(this.clone(this.dataset[keys[i]]));
+            //} else {
+            //    result.push({error: utils.ERRORS.ERROR_PERMISSION});
+            //}
         }
         typeof callback === 'function' && setImmediate(() => callback(null, result));
     }
@@ -1867,7 +1869,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             callback = options;
             options = null;
         }
-        if (!callback) {
+        /*if (!callback) {
             return new Promise((resolve, reject) => {
                 this.getObjects(keys, options, (err, objs) => {
                     if (err) {
@@ -1877,19 +1879,19 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 }, dontModify);
             });
-        }
+        }*/
 
         if (options && options.acl) {
             options.acl = null;
         }
         if (typeof callback === 'function') {
-            utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_READ, (err, options) => {
-                if (err) {
-                    setImmediate(() => callback(err));
-                } else {
-                    return this._getObjects(keys, options, callback, dontModify);
-                }
-            });
+            //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_READ, (err, options) => {
+            //    if (err) {
+            //        setImmediate(() => callback(err));
+            //    } else {
+            return this._getObjects(keys, options, callback, dontModify);
+            //    }
+            //});
         }
     }
 
@@ -2178,7 +2180,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             callback = options;
             options = null;
         }
-        if (!callback) {
+        /*if (!callback) {
             return new Promise((resolve, reject) => {
                 this.delObject(id, options, err => {
                     if (err) {
@@ -2188,18 +2190,18 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 });
             });
-        }
+        }*/
 
         if (options && options.acl) {
             options.acl = null;
         }
-        utils.checkObjectRights(this, id, this.dataset[id], options, utils.CONSTS.ACCESS_DELETE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                return this._delObject(id, options, callback);
-            }
-        });
+        //utils.checkObjectRights(this, id, this.dataset[id], options, utils.CONSTS.ACCESS_DELETE, (err, options) => {
+        //    if (err) {
+        //        typeof callback === 'function' && setImmediate(() => callback(err));
+        //    } else {
+        return this._delObject(id, options, callback);
+        //    }
+        //});
     }
 
     /*
@@ -2238,9 +2240,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 }
             }
             if (this.dataset[id]) {
-                if (!utils.checkObject(this.dataset[id], options, utils.CONSTS.ACCESS_READ)) {
+                /*if (!utils.checkObject(this.dataset[id], options, utils.CONSTS.ACCESS_READ)) {
                     continue;
-                }
+                }*/
                 try {
                     f(this.dataset[id]);
                 } catch (e) {
@@ -2273,7 +2275,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             callback = options;
             options = null;
         }
-        if (!callback) {
+        /*if (!callback) {
             return new Promise((resolve, reject) => {
                 this._applyView(func, params, options, (err, obj) => {
                     if (err) {
@@ -2283,20 +2285,20 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 });
             });
-        }
+        }*/
 
         if (options && options.acl) {
             options.acl = null;
         }
 
         if (typeof callback === 'function') {
-            utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-                if (err) {
-                    setImmediate(() => callback(err));
-                } else {
-                    return this._applyViewFunc(func, params, options, callback);
-                }
-            });
+            //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
+            //    if (err) {
+            //        setImmediate(() => callback(err));
+            //    } else {
+            return this._applyViewFunc(func, params, options, callback);
+            //    }
+            //});
         }
     }
 
@@ -2320,7 +2322,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             callback = options;
             options = null;
         }
-        if (!callback) {
+        /*if (!callback) {
             return new Promise((resolve, reject) => {
                 this.getObjectView(design, search, params, options, (err, obj) => {
                     if (err) {
@@ -2330,20 +2332,20 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                     }
                 });
             });
-        }
+        }*/
 
         if (options && options.acl) {
             options.acl = null;
         }
 
         if (typeof callback === 'function') {
-            utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-                if (err) {
-                    setImmediate(() => callback(err));
-                } else {
-                    return this._getObjectView(design, search, params, options, callback);
-                }
-            });
+            //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
+            //    if (err) {
+            //        setImmediate(() => callback(err));
+            //    } else {
+            return this._getObjectView(design, search, params, options, callback);
+            //    }
+            //});
         }
     }
 

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -454,7 +454,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         const location = path.join(this.objectsDir, id, name);
 
         try {
-            const stat = fs.lstatSync(location);
+            const stat = fs.statSync(location);
             return stat.isFile();
         } catch (e) {
             if (e.code !== 'ENOENT') {

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -187,66 +187,62 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             metaObjects[obj.id] = obj.value.common.type;
         });
 
-        try {
-            if (!fs.existsSync(this.objectsDir)) {
-                return {
-                    numberSuccess: resSynced,
-                    notifications: resNotifies
-                };
-            }
-            const baseDirs = fs.readdirSync(this.objectsDir);
-            baseDirs.forEach(dir => {
-                let dirSynced = 0;
-                if (dir === '..' || dir === '.') {
-                    return;
-                }
-                const dirPath = path.join(this.objectsDir, dir);
-                const stat = fs.statSync(dirPath);
-                if (!stat.isDirectory()) {
-                    return;
-                }
-                if (limitId && dir !== limitId) {
-                    return;
-                }
-                if (!metaObjects[dir]) {
-                    resNotifies.push('Ignoring Directory "' + dir + '" because officially not created as meta object. Please remove directory!');
-                    return;
-                }
-                this._loadFileSettings(dir);
-                const files = getAllFiles(dirPath);
-                files.forEach(file => {
-                    const localFile = file.substr(dirPath.length + 1);
-                    if (localFile === '_data.json') {
-                        return;
-                    }
-                    if (!this.fileOptions[dir][localFile]) {
-                        const fileStat    = fs.statSync(file);
-                        const ext         = path.extname(localFile);
-                        const mime        = utils.getMimeType(ext);
-                        const _mimeType   = mime.mimeType;
-                        const isBinary    = mime.isBinary;
-
-                        this.fileOptions[dir][localFile] = {
-                            createdAt: fileStat.ctimeMs,
-                            acl      : {
-                                owner:       (this.defaultNewAcl && this.defaultNewAcl.owner)      || utils.CONSTS.SYSTEM_ADMIN_USER,
-                                ownerGroup:  (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || utils.CONSTS.SYSTEM_ADMIN_GROUP,
-                                permissions: (this.defaultNewAcl && this.defaultNewAcl.file)       || (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_READ | utils.CONSTS.ACCESS_EVERY_READ)// 0x644
-                            },
-                            mimeType  : _mimeType,
-                            binary    : isBinary,
-                            modifiedAt: fileStat.mtimeMs
-                        };
-                        dirSynced++;
-                    }
-                });
-                this._saveFileSettings(dir);
-                resSynced += dirSynced;
-                dirSynced && resNotifies.push('Added ' + dirSynced + ' Files in Directory "' + dir + '"');
-            });
-        } catch (e) {
-            throw e;
+        if (!fs.existsSync(this.objectsDir)) {
+            return {
+                numberSuccess: resSynced,
+                notifications: resNotifies
+            };
         }
+        const baseDirs = fs.readdirSync(this.objectsDir);
+        baseDirs.forEach(dir => {
+            let dirSynced = 0;
+            if (dir === '..' || dir === '.') {
+                return;
+            }
+            const dirPath = path.join(this.objectsDir, dir);
+            const stat = fs.statSync(dirPath);
+            if (!stat.isDirectory()) {
+                return;
+            }
+            if (limitId && dir !== limitId) {
+                return;
+            }
+            if (!metaObjects[dir]) {
+                resNotifies.push('Ignoring Directory "' + dir + '" because officially not created as meta object. Please remove directory!');
+                return;
+            }
+            this._loadFileSettings(dir);
+            const files = getAllFiles(dirPath);
+            files.forEach(file => {
+                const localFile = file.substr(dirPath.length + 1);
+                if (localFile === '_data.json') {
+                    return;
+                }
+                if (!this.fileOptions[dir][localFile]) {
+                    const fileStat    = fs.statSync(file);
+                    const ext         = path.extname(localFile);
+                    const mime        = utils.getMimeType(ext);
+                    const _mimeType   = mime.mimeType;
+                    const isBinary    = mime.isBinary;
+
+                    this.fileOptions[dir][localFile] = {
+                        createdAt: fileStat.ctimeMs,
+                        acl      : {
+                            owner:       (this.defaultNewAcl && this.defaultNewAcl.owner)      || utils.CONSTS.SYSTEM_ADMIN_USER,
+                            ownerGroup:  (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || utils.CONSTS.SYSTEM_ADMIN_GROUP,
+                            permissions: (this.defaultNewAcl && this.defaultNewAcl.file)       || (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_READ | utils.CONSTS.ACCESS_EVERY_READ)// 0x644
+                        },
+                        mimeType  : _mimeType,
+                        binary    : isBinary,
+                        modifiedAt: fileStat.mtimeMs
+                    };
+                    dirSynced++;
+                }
+            });
+            this._saveFileSettings(dir);
+            resSynced += dirSynced;
+            dirSynced && resNotifies.push('Added ' + dirSynced + ' Files in Directory "' + dir + '"');
+        });
         return {
             numberSuccess: resSynced,
             notifications: resNotifies

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -13,14 +13,12 @@
 /* jshint -W061 */
 'use strict';
 
-//const extend                = require('node.extend');
 const fs                    = require('fs-extra');
 const path                  = require('path');
 const InMemoryFileDB        = require('@iobroker/db-base').inMemoryFileDB;
 const tools                 = require('@iobroker/db-base').tools;
 const utils                 = require('@iobroker/db-objects-redis').objectsUtils;
 const deepClone             = require('deep-clone');
-//const { isDeepStrictEqual } = require('util');
 
 /**
  * This class inherits InMemoryFileDB class and adds all relevant logic for objects
@@ -57,37 +55,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         // cached meta information for file operations
         this.existingMetaObjects = {};
 
-        /*function prepareRights(options) {
-         let fOptions = {};
-         options = options || {};
-         if (!options.user) {
-         options = {
-         user: SYSTEM_ADMIN_USER,
-         params: options
-         };
-         }
-
-         // acl.owner = user this creates or owns the file
-         // acl.group = group, this assigned to file
-         // acl.permissions = '0777' - default 1 (execute, 2 write, 4 read
-         if (!options.user) {
-         fOptions.acl = {
-         owner:      SYSTEM_ADMIN_USER,
-         ownerGroup: SYSTEM_ADMIN_GROUP,
-         permissions: 0x644 // '0777'
-         };
-         } else {
-         fOptions.acl = {
-         owner: options.user
-         };
-         fOptions.acl.ownerGroup  = options.group;
-         fOptions.acl.permissions = 0x644;
-         }
-         fOptions.acl.ownerGroup  = fOptions.acl.ownerGroup || SYSTEM_ADMIN_GROUP;
-
-         return fOptions;
-         }*/
-
         // Handle some < js-controller 2.0 broken objects and correct them
         for (const key of Object.keys(this.dataset)) {
             if (typeof this.dataset[key] === 'object' && this.dataset[key].acl && this.dataset[key].acl.permissions && !this.dataset[key].acl.object) {
@@ -101,29 +68,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             this.defaultNewAcl = deepClone(this.dataset['system.config'].common.defaultNewAcl);
         }
     }
-
-    /*/**
-     * Checks if given Id is a meta object, else throws error
-     *
-     * @param {string} id to check
-     * @throws Error if id is invalid
-     */
-    // check later, remove
-    /*
-    async validateMetaObject(id) {
-        if (this.existingMetaObjects[id] === undefined) {
-            // if not cached -> getObject
-            const obj = await this.getObjectAsync(id);
-            if (obj && obj.type === 'meta') {
-                this.existingMetaObjects[id] = true;
-            } else {
-                this.existingMetaObjects[id] = false;
-                return Promise.reject(new Error(`${id} is not an object of type "meta"`));
-            }
-        } else if (this.existingMetaObjects[id] === false) {
-            return Promise.reject(new Error(`${id} is not an object of type "meta"`));
-        }
-    }*/
 
     // internal functionality
     normalizeFilename(name) {
@@ -173,7 +117,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
     }
 
-    // internal functionlity
+    // internal functionality
     loadFileSettings(id) {
         if (!this.fileOptions[id]) {
             const location = path.join(this.objectsDir, id, '_data.json');
@@ -207,72 +151,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
     }
 
-    // check later
-    /*checkFile(id, name, options, flag, callback) {
-        this.loadFileSettings(id);
-
-        const acl = this.fileOptions[id][name] || {};
-
-        if (utils.checkFile(acl, options, flag, this.defaultNewAcl)) {
-            return callback && callback(false, options);
-        } else {
-            return callback && callback(true, options);
-        }
-    }*/
-
-    // needed by server, check later
-    /*checkFileRights(id, name, options, flag, callback) {
-        return utils.checkFileRights(this, id, name, options, flag, callback);
-    }*/
-
-    /*
-    setDefaultAcl(callback) {
-        try {
-            // deep copy
-            this.defaultNewAcl = deepClone(this.dataset['system.config'].common.defaultNewAcl);
-        } catch (e) {
-            this.defaultNewAcl = {
-                owner:      utils.CONSTS.SYSTEM_ADMIN_USER,
-                ownerGroup: utils.CONSTS.SYSTEM_ADMIN_GROUP,
-                object:     (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_RW | utils.CONSTS.ACCESS_EVERY_READ),
-                state:      (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_RW | utils.CONSTS.ACCESS_EVERY_READ),
-                file:       (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_RW | utils.CONSTS.ACCESS_EVERY_READ)
-            };
-            this.dataset['system.config'].common.defaultNewAcl = deepClone(this.defaultNewAcl);
-        }
-
-        let count = 0;
-        // Set all objects without ACL to this one
-        for (const id of Object.keys(this.dataset)) {
-            if (this.dataset[id] && !this.dataset[id].acl) {
-                // deep copy
-                this.dataset[id].acl = deepClone(this.defaultNewAcl);
-                delete this.dataset[id].acl.file;
-                if (this.dataset[id].type !== 'state') {
-                    delete this.dataset[id].acl.state;
-                }
-
-                count++;
-            }
-        }
-
-        typeof callback === 'function' && callback(null, count);
-    }*/
-
-    // check later
-    /*getUserGroup(user, callback) {
-        return utils.getUserGroup(this, user, (error, user, userGroups, userAcl) => {
-            error && this.log.error(`${this.namespace} ${error}`);
-            callback(user, userGroups, userAcl);
-        });
-    }*/
-
-    /*
-    insert(id, attName, ignore, options, obj, callback) {
-        return utils.insert(this, id, attName, ignore, options, obj, callback);
-    }*/
-
-    // special server functionality
+    // server only functionality
     syncFileDirectory(limitId, callback) {
         if (typeof limitId === 'function') {
             callback = limitId;
@@ -378,9 +257,32 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    _writeFile(id, name, data, options, callback) {
+    async writeFile(id, name, data, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+            options = null;
+        }
+        if (typeof options === 'string') {
+            options = {mimeType: options};
+        }
+        if (options && options.acl) {
+            options.acl = null;
+        }
+
+        const _path = utils.sanitizePath(id, name, callback);
+        if (!_path) {
+            return;
+        }
+        id = _path.id;
+        name = _path.name;
+
         options = options || {};
+
         try {
+            this.loadFileSettings(id);
+
+            this.files[id] = this.files[id] || {};
+
             try {
                 if (!fs.existsSync(this.objectsDir)) {
                     fs.mkdirSync(this.objectsDir);
@@ -437,35 +339,14 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    async writeFile(id, name, data, options, callback) {
+    async readFile(id, name, options, callback) {
         if (typeof options === 'function') {
             callback = options;
-            options = null;
-        }
-        if (typeof options === 'string') {
-            options = {mimeType: options};
+            options  = null;
         }
         if (options && options.acl) {
             options.acl = null;
         }
-        /*if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.writeFile(id, name, data, options, (err, res, mimeType) => {
-                    if (!err) {
-                        resolve({res, mimeType});
-                    } else {
-                        reject(err);
-                    }
-                });
-            });
-        }*/
-
-        /*try {
-            await this.validateMetaObject(id);
-        } catch (e) {
-            this.log.error(`Cannot write file ${name}: ${e.message}`);
-            return tools.maybeCallbackWithError(callback, e);
-        }*/
 
         const _path = utils.sanitizePath(id, name, callback);
         if (!_path) {
@@ -474,26 +355,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         id = _path.id;
         name = _path.name;
 
-        try {
-            this.loadFileSettings(id);
-
-            this.files[id] = this.files[id] || {};
-
-            // If file yet exists => check the permissions
-            //return this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            //    if (err) {
-            //        return tools.maybeCallbackWithError(callback, err);
-            //    } else {
-            return this._writeFile(id, name, data, options, callback);
-            //    }
-            //});
-        } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
-        }
-    }
-
-    // needed by server
-    _readFile(id, name, options, callback) {
         options = options || {};
         try {
             this.loadFileSettings(id);
@@ -555,60 +416,23 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 };
             }
 
-            if (typeof callback === 'function') {
-                if (this.fileOptions[id][name] !== null && this.fileOptions[id][name] !== undefined) {
-                    if (!this.fileOptions[id][name].mimeType) {
-                        const _ext = path.extname(name);
-                        const _mimeType = utils.getMimeType(_ext);
-                        this.fileOptions[id][name].mimeType = _mimeType.mimeType;
-                    }
-                    setImmediate((fileContent, fileMime) => callback(null, fileContent, fileMime), this.files[id][name], this.fileOptions[id][name].mimeType);
-                } else {
-                    return tools.maybeCallbackWithError(callback, utils.ERRORS.ERROR_NOT_FOUND);
+            if (typeof callback !== 'function') { // no need to do anything if no callback is there to return it
+                return;
+            }
+            if (this.fileOptions[id][name] !== null && this.fileOptions[id][name] !== undefined) {
+                if (!this.fileOptions[id][name].mimeType) {
+                    const _ext = path.extname(name);
+                    const _mimeType = utils.getMimeType(_ext);
+                    this.fileOptions[id][name].mimeType = _mimeType.mimeType;
                 }
+                setImmediate((fileContent, fileMime) => callback(null, fileContent, fileMime), this.files[id][name], this.fileOptions[id][name].mimeType);
+            } else {
+                return tools.maybeCallbackWithError(callback, utils.ERRORS.ERROR_NOT_FOUND);
             }
         } catch (e) {
             this.log.warn(`Cannot read file ${id} / ${name}: ${JSON.stringify(e)}`);
             return tools.maybeCallbackWithError(callback, e);
         }
-    }
-
-    // needed by server
-    async readFile(id, name, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options  = null;
-        }
-        if (options && options.acl) {
-            options.acl = null;
-        }
-
-        /*if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.readFile(id, name, options, (err, res, mimeType) =>{
-                    if (!err) {
-                        resolve({data: res, mimeType: mimeType});
-                    } else {
-                        reject(err);
-                    }
-                });
-            });
-        }*/
-
-        const _path = utils.sanitizePath(id, name, callback);
-        if (!_path) {
-            return;
-        }
-        id = _path.id;
-        name = _path.name;
-
-        //this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, (err, options) => {
-        //    if (err) {
-        //        typeof callback === 'function' && setImmediate(() => callback(err));
-        //    } else {
-        return this._readFile(id, name, options, callback);
-        //    }
-        //});
     }
 
     /**
@@ -625,15 +449,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
 
         try {
-            /*await new Promise((resolve, reject) => {
-                utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, err => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve();
-                    }
-                });
-            });*/
             // check if the id exists
             return Object.prototype.hasOwnProperty.call(this.dataset, id);
         } catch (e) {
@@ -659,16 +474,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         const location = path.join(this.objectsDir, id, name);
 
         try {
-            /*await new Promise((resolve, reject) => {
-                this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, err => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve();
-                    }
-                });
-            });
-            */
             const stat = await fs.promises.lstat(location);
             return Promise.resolve(stat.isFile());
         } catch (e) {
@@ -688,7 +493,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
      * @param {object} [_options] optional user context
      * @returns {Promise<boolean>}
      */
-    // special functionality Server
+    // special functionality only for Server (used together with SyncFileDirectory)
     async dirExists(id, name, _options) {
         if (typeof name !== 'string') {
             name = '';
@@ -697,15 +502,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         const location = path.join(this.objectsDir, id, name);
 
         try {
-            /*await new Promise((resolve, reject) => {
-                this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, err => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve();
-                    }
-                });
-            });*/
             const stat = await fs.promises.lstat(location);
             return Promise.resolve(stat.isDirectory());
         } catch (e) {
@@ -718,7 +514,18 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // needed by server
-    _unlink(id, name, options, callback) {
+    unlink(id, name, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+            options  = null;
+        }
+        const _path = utils.sanitizePath(id, name, callback);
+        if (!_path) {
+            return;
+        }
+        id   = _path.id;
+        name = _path.name;
+
         try {
             let changed = false;
 
@@ -782,42 +589,31 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             return tools.maybeCallbackWithError(callback, e);
         }
     }
+
     // needed by server
-    unlink(id, name, options, callback) {
+    async readDir(id, name, options, callback) {
         if (typeof options === 'function') {
             callback = options;
-            options  = null;
+            options = null;
         }
-        /*if (options && options.acl) {
+        if (options && options.acl) {
             options.acl = null;
-        }*/
-        const _path = utils.sanitizePath(id, name, callback);
-        if (!_path) {
+        }
+        if ((id === '' || id === '/' || id === '*') && (name === '' || name === '*')) {
+            // read root of xxx-data/files
+        } else {
+            const _path = utils.sanitizePath(id, name, callback);
+            if (!_path) {
+                return;
+            }
+            id = _path.id;
+            name = _path.name;
+        }
+
+        if (typeof callback !== 'function') { // no need to do anything if no callback is there to return it
             return;
         }
-        id   = _path.id;
-        name = _path.name;
 
-        //this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-        //    if (err) {
-        //        typeof callback === 'function' && setImmediate(() => callback(err));
-        //    } else {
-        //        if (!options.acl.file['delete']) {
-        //            typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-        //        } else {
-        return this._unlink(id, name, options, callback);
-        //        }
-        //    }
-        //});
-    }
-
-    /*
-    delFile(id, name, options, callback) {
-        return this.unlink(id, name, options, callback);
-    }*/
-
-    // needed by server
-    _readDir(id, name, options, callback) {
         options = options || {};
         // Find all files and directories starts with name
         const _files = [];
@@ -943,41 +739,23 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
         typeof callback === 'function' && setImmediate(() => callback(null, res));
     }
+
     // needed by server
-    async readDir(id, name, options, callback) {
+    rename(id, oldName, newName, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
         }
-        if (options && options.acl) {
-            options.acl = null;
+        const _path = utils.sanitizePath(id, oldName, callback);
+        if (!_path) {
+            return;
         }
-        if ((id === '' || id === '/' || id === '*') && (name === '' || name === '*')) {
-            // read root of xxx-data/files
-        } else {
-            const _path = utils.sanitizePath(id, name, callback);
-            if (!_path) {
-                return;
-            }
-            id = _path.id;
-            name = _path.name;
+        id = _path.id;
+        oldName = _path.name;
+        if (newName[0] === '/') {
+            newName = newName.substring(1);
         }
 
-        //this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, (err, options) => {
-        //    if (err) {
-        //        typeof callback === 'function' && setImmediate(() => callback(err));
-        //    } else {
-        //        if (!options.acl.file.list) {
-        //            typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-        //        } else {
-        return this._readDir(id, name, options, callback);
-        //        }
-        //    }
-        //});
-    }
-
-    // needed by server
-    _rename(id, oldName, newName, _options, callback) {
         try {
             this.loadFileSettings(id);
 
@@ -1008,509 +786,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
     }
 
-    // needed by server
-    rename(id, oldName, newName, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        /*if (options && options.acl) {
-            options.acl = null;
-        }*/
-        const _path = utils.sanitizePath(id, oldName, callback);
-        if (!_path) {
-            return;
-        }
-        id = _path.id;
-        oldName = _path.name;
-        if (newName[0] === '/') {
-            newName = newName.substring(1);
-        }
-
-        //this.checkFileRights(id, oldName, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-        //    if (err) {
-        //        typeof callback === 'function' && setImmediate(() => callback(err));
-        //    } else {
-        //        if (!options.acl.file.write) {
-        //            typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-        //        } else {
-        return this._rename(id, oldName, newName, options, callback);
-        //        }
-        //    }
-        //});
-    }
-
-    /*
-    _touch(id, name, options, callback) {
-        try {
-            this.loadFileSettings(id);
-
-            const regEx = new RegExp(tools.pattern2RegEx(name));
-            const processed = [];
-            const now = Date.now();
-            let changed = false;
-            for (const f of Object.keys(this.fileOptions[id])) {
-                if (regEx.test(f) && utils.checkFile(this.fileOptions[id][f], options, utils.CONSTS.ACCESS_WRITE)) {
-                    changed = true;
-                    // Check if file exists
-                    if (fs.existsSync(path.join(this.objectsDir, id, f))) {
-                        if (!this.fileOptions[id][f]) {
-                            this.fileOptions[id][f] = {};
-                            this.fileOptions[id][f].createdAt = now;
-                        }
-
-                        if (typeof this.fileOptions[id][f] !== 'object') {
-                            this.fileOptions[id][f] = {
-                                mimeType: this.fileOptions[id][f]
-                            };
-                        }
-
-                        if (!this.fileOptions[id][f].mimeType) {
-                            const ext = path.extname(name);
-                            const mimeType = utils.getMimeType(ext);
-                            this.fileOptions[id][f].binary   = mimeType.isBinary;
-                            this.fileOptions[id][f].mimeType = mimeType.mimeType;
-                        }
-
-                        if (!this.fileOptions[id][f].acl) {
-                            this.fileOptions[id][f].acl = {
-                                owner:       (this.defaultNewAcl && this.defaultNewAcl.owner)      || utils.CONSTS.SYSTEM_ADMIN_USER,
-                                ownerGroup:  (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || utils.CONSTS.SYSTEM_ADMIN_GROUP,
-                                permissions: (this.defaultNewAcl && this.defaultNewAcl.file)       || (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_READ | utils.CONSTS.ACCESS_EVERY_READ) // '0644'
-                            };
-                        }
-                        const fOp = this.fileOptions[id][f];
-                        fOp.modifiedAt = now;
-
-                        const stats = fs.statSync(path.join(this.objectsDir, id, f));
-                        const fileName = path.basename(f);
-                        processed.push({
-                            path:       path.dirname(f),
-                            file:       fileName,
-                            stats:      stats,
-                            isDir:      stats.isDirectory(),
-                            acl:        fOp.acl || {},
-                            modifiedAt: fOp.modifiedAt,
-                            createdAt:  fOp.createdAt
-                        });
-                    } else {
-                        delete this.fileOptions[id][f];
-                    }
-                }
-            }
-
-            // Store dir description
-            if (changed) {
-                fs.writeFileSync(path.join(this.objectsDir, id, '_data.json'), JSON.stringify(this.fileOptions[id]));
-            }
-
-            typeof callback === 'function' && setImmediate(() => callback(null, processed));
-        } catch (e) {
-            typeof callback === 'function' && setImmediate(() => callback(e.message));
-        }
-    }
-    touch(id, name, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        if (options && options.acl) {
-            options.acl = null;
-        }
-        const _path = utils.sanitizePath(id, name, callback);
-        if (!_path) {
-            return;
-        }
-        id = _path.id;
-        name = _path.name;
-
-        this.checkFileRights(id, null, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                return this._touch(id, name, options, callback);
-            }
-        });
-    }*/
-
-    /*
-    _rm(id, name, options, callback) {
-        try {
-            this.loadFileSettings(id);
-
-            const regEx = new RegExp(tools.pattern2RegEx(name));
-            const processed = [];
-            let changed = false;
-            const dirs = [];
-            for (const f of Object.keys(this.fileOptions[id])) {
-                if (regEx.test(f) && utils.checkFile(this.fileOptions[id][f], options, utils.CONSTS.ACCESS_WRITE)) {
-                    let stat;
-                    if (this.fileOptions[id][f]) {
-                        changed = true;
-                        delete this.fileOptions[id][f];
-                    }
-                    if (this.files && this.files[id] && this.files[id][f]) {
-                        delete this.files[id][f];
-                    }
-                    const location = path.join(this.objectsDir, id, f);
-                    if (fs.existsSync(location)) {
-                        stat = fs.statSync(location);
-
-                        if (stat.isDirectory()) {
-                            if (dirs.indexOf(f) === -1) {
-                                dirs.push(f);
-                            }
-                        } else {
-                            fs.unlinkSync(location);
-                        }
-                    }
-                    const filePath = path.dirname(f);
-                    const fileName = path.basename(f);
-                    if (dirs.indexOf(filePath) === -1) {
-                        dirs.push(filePath);
-                    }
-                    processed.push({
-                        path:       filePath,
-                        file:       fileName,
-                        isDir:      stat && stat.isDirectory()
-                    });
-                }
-            }
-
-            // try to delete directories
-            for (let d = 0; d < dirs.length; d++) {
-                try {
-                    const _files = fs.readdirSync(path.join(this.objectsDir, id, dirs[d]));
-
-                    if (_files.length) {
-                        this.log.warn('Directory ' + path.join(id, dirs[d]) + ' is not empty');
-                    } else {
-                        fs.rmdirSync(path.join(this.objectsDir, id, dirs[d]));
-                    }
-                } catch (e) {
-                    this.log.error('Cannot delete ' + path.join(id, dirs[d]) + ': ' + e);
-                }
-            }
-
-            // Store dir description
-            if (changed) {
-                if (fs.existsSync(path.join(this.objectsDir, id))) {
-                    fs.writeFileSync(path.join(this.objectsDir, id, '_data.json'), JSON.stringify(this.fileOptions[id]));
-                } else {
-                    delete this.fileOptions[id];
-                }
-            }
-
-            typeof callback === 'function' && setImmediate(() => callback(null, processed));
-        } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
-        }
-    }
-    rm(id, name, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        if (options && options.acl) {
-            options.acl = null;
-        }
-        const _path = utils.sanitizePath(id, name, callback);
-        if (!_path) {
-            return;
-        }
-        id = _path.id;
-        name = _path.name;
-
-        this.checkFileRights(id, null, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                if (!options.acl.file['delete']) {
-                    typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-                } else {
-                    return this._rm(id, name, options, callback);
-                }
-            }
-        });
-    }*/
-
-    /*
-    _mkdir(id, dirname, _options, callback) {
-        try {
-            this.loadFileSettings(id);
-
-            if (!fs.existsSync(path.join(this.objectsDir, id, dirname))) {
-                fs.mkdirSync(path.join(this.objectsDir, id, dirname));
-                typeof callback === 'function' && setImmediate(() => callback());
-            } else {
-                typeof callback === 'function' && setImmediate(() => callback('Yet exists'));
-            }
-        } catch (e) {
-            typeof callback === 'function' && setImmediate(() => callback(e.message));
-        }
-    }
-    mkdir(id, dirname, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        if (options && options.acl) {
-            options.acl = null;
-        }
-        const _path = utils.sanitizePath(id, dirname, callback);
-        if (!_path) {
-            return;
-        }
-        id = _path.id;
-        dirname = _path.name;
-
-        this.checkFileRights(id, dirname, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                if (!options.acl.file.write) {
-                    typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-                } else {
-                    return this._mkdir(id, dirname, options, callback);
-                }
-            }
-        });
-    }*/
-
-    /*
-    _chownFile(id, name, options, callback) {
-        try {
-            this.loadFileSettings(id);
-
-            const regEx = new RegExp(tools.pattern2RegEx(name));
-            const processed = [];
-            let changed = false;
-            for (const f of Object.keys(this.fileOptions[id])) {
-                if (regEx.test(f) && utils.checkFile(this.fileOptions[id][f], options, utils.CONSTS.ACCESS_WRITE)) {
-                    changed = true;
-                    if (typeof this.fileOptions[id][f] !== 'object') {
-                        this.fileOptions[id][f] = {
-                            mimeType: this.fileOptions[id][f]
-                        };
-                    }
-
-                    if (!this.fileOptions[id][f].acl) {
-                        this.fileOptions[id][f].acl = {
-                            owner:       (this.defaultNewAcl && this.defaultNewAcl.owner)      || utils.CONSTS.SYSTEM_ADMIN_USER,
-                            ownerGroup:  (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || utils.CONSTS.SYSTEM_ADMIN_GROUP,
-                            permissions: (this.defaultNewAcl && this.defaultNewAcl.file)       || (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_READ | utils.CONSTS.ACCESS_EVERY_READ) // '0644'
-                        };
-                    }
-
-                    this.fileOptions[id][f].acl.owner      = options.owner;
-                    this.fileOptions[id][f].acl.ownerGroup = options.ownerGroup;
-
-                    if (fs.existsSync(path.join(this.objectsDir, id, f))) {
-                        const stats = fs.statSync(path.join(this.objectsDir, id, f));
-                        const acl = this.fileOptions[id][f];
-                        const fileName = path.basename(f);
-                        processed.push({
-                            path:       path.dirname(f),
-                            file:       fileName,
-                            stats:      stats,
-                            isDir:      stats.isDirectory(),
-                            acl:        acl.acl || {},
-                            modifiedAt: this.fileOptions[id][f].modifiedAt,
-                            createdAt:  this.fileOptions[id][f].createdAt
-                        });
-                    }
-                }
-            }
-
-            // Store dir description
-            if (changed) {
-                fs.writeFileSync(path.join(this.objectsDir, id, '_data.json'), JSON.stringify(this.fileOptions[id]));
-            }
-            typeof callback === 'function' && setImmediate(() => callback(null, processed, id));
-        } catch (e) {
-            typeof callback === 'function' && setImmediate(() => callback(e.message));
-        }
-    }
-    chownFile(id, name, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        options = options || {};
-        if (typeof options !== 'object') {
-            options = {owner: options};
-        }
-        options.acl = null;
-        const _path = utils.sanitizePath(id, name, callback);
-        if (!_path) {
-            return;
-        }
-        id = _path.id;
-        name = _path.name;
-
-        if (!options.ownerGroup && options.group) {
-            options.ownerGroup = options.group;
-        }
-        if (!options.owner      && options.user)  {
-            options.owner      = options.user;
-        }
-
-        if (!options.owner) {
-            this.log.error(this.namespace + ' user is not defined');
-            typeof callback === 'function' && setImmediate(() => callback('invalid parameter'));
-            return;
-        }
-
-        if (!options.ownerGroup) {
-            // get user group
-            this.getUserGroup(options.owner, (_user, groups) => {
-                if (!groups || !groups[0]) {
-                    typeof callback === 'function' && setImmediate(() => callback('user "' + options.owner + '" belongs to no group'));
-                    return;
-                } else {
-                    options.ownerGroup = groups[0];
-                }
-                this.chownFile(id, name, options, callback);
-            });
-            return;
-        }
-
-        this.checkFileRights(id, null, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                if (!options.acl.file.write) {
-                    typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-                } else {
-                    return this._chownFile(id, name, options, callback);
-                }
-            }
-        });
-    }*/
-
-    /*
-    _chmodFile(id, name, options, callback) {
-        try {
-            this.loadFileSettings(id);
-
-            const regEx = new RegExp(tools.pattern2RegEx(name));
-            const processed = [];
-            let changed = false;
-            for (const f in Object.keys(this.fileOptions[id])) {
-                if (regEx.test(f) && utils.checkFile(this.fileOptions[id][f], options, utils.CONSTS.ACCESS_WRITE)) {
-                    changed = true;
-                    if (typeof this.fileOptions[id][f] !== 'object') {
-                        this.fileOptions[id][f] = {
-                            mimeType: this.fileOptions[id][f]
-                        };
-                    }
-
-                    if (!this.fileOptions[id][f].acl) {
-                        this.fileOptions[id][f].acl = {
-                            owner:       (this.defaultNewAcl && this.defaultNewAcl.owner)      || utils.CONSTS.SYSTEM_ADMIN_USER,
-                            ownerGroup:  (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || utils.CONSTS.SYSTEM_ADMIN_GROUP,
-                            permissions: (this.defaultNewAcl && this.defaultNewAcl.file)       || (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_READ | utils.CONSTS.ACCESS_EVERY_READ) // '0644'
-                        };
-                    }
-
-                    this.fileOptions[id][f].acl.permissions = options.mode;
-                    if (fs.existsSync(path.join(this.objectsDir, id, f))) {
-                        const stats = fs.statSync(path.join(this.objectsDir, id, f));
-                        const acl = this.fileOptions[id][f];
-                        const fileName = path.basename(f);
-                        processed.push({
-                            path:       path.dirname(f),
-                            file:       fileName,
-                            stats:      stats,
-                            isDir:      stats.isDirectory(),
-                            acl:        acl.acl || {},
-                            modifiedAt: acl.modifiedAt,
-                            createdAt:  acl.createdAt
-                        });
-                    }
-                }
-            }
-
-            // Store dir description
-            if (changed) {
-                fs.writeFileSync(path.join(this.objectsDir, id, '_data.json'), JSON.stringify(this.fileOptions[id]));
-            }
-            typeof callback === 'function' && setImmediate(() => callback(null, processed, id));
-        } catch (e) {
-            typeof callback === 'function' && setImmediate(() => callback(e.message));
-        }
-    }
-    chmodFile(id, name, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        options = options || {};
-        options.acl = null;
-
-        const _path = utils.sanitizePath(id, name, callback);
-        if (!_path) {
-            return;
-        }
-        id = _path.id;
-        name = _path.name;
-
-        if (typeof options !== 'object') {
-            options = {mode: options};
-        }
-
-        if (options.mode === undefined) {
-            this.log.error(this.namespace + ' mode is not defined');
-            typeof callback === 'function' && setImmediate(() => callback('invalid parameter'));
-            return;
-        } else if (typeof options.mode === 'string') {
-            options.mode = parseInt(options.mode, 16);
-        }
-
-        this.checkFileRights(id, null, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                if (!options.acl.file.write) {
-                    typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-                } else {
-                    return this._chmodFile(id, name, options, callback);
-                }
-            }
-        });
-    }*/
-
-    /*
-    _enableFileCache(enabled, _options, callback) {
-        if (this.settings.connection.noFileCache !== enabled) {
-            this.settings.connection.noFileCache = !!enabled;
-            if (!this.settings.connection.noFileCache) {
-                // clear cache
-                this.files = {};
-            }
-        }
-        typeof callback === 'function' && setImmediate(() => callback(null, this.settings.connection.noFileCache));
-    }
-    enableFileCache(enabled, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-
-        if (options && options.acl) {
-            options.acl = null;
-        }
-
-        utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                return this._enableFileCache(enabled, options, callback);
-            }
-        });
-    }*/
-
-    // -------------- OBJECT FUNCTIONS -------------------------------------------
     // internal functionality
     clone(obj) {
         if (obj === null || obj === undefined || !tools.isObject(obj)) {
@@ -1525,22 +800,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         return temp;
     }
 
-    /*
-    subscribe(pattern, options, callback) {
-        return this.subscribeConfig(pattern, options, callback);
-    }
-
-    subscribeConfig(pattern, options, callback) {
-        this.subscribeConfigForClient(this.callbackSubscriptionClient, pattern, options, callback);
-    }*/
-
-    // needed by server
-    _subscribeConfigForClient(client, pattern, options, callback) {
-        this.handleSubscribe(client, 'objects', pattern, options);
-
-        typeof callback === 'function' && setImmediate(() => callback());
-    }
-
     // needed by server
     subscribeConfigForClient(client, pattern, options, callback) {
         if (typeof options === 'function') {
@@ -1548,28 +807,8 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             options = null;
         }
 
-        //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-        //    if (err) {
-        //        typeof callback === 'function' && setImmediate(() => callback(err));
-        //    } else {
-        return this._subscribeConfigForClient(client, pattern, options, callback);
-        //    }
-        //});
-    }
+        this.handleSubscribe(client, 'objects', pattern, options);
 
-    /*
-    unsubscribe(pattern, options, callback) {
-        this.unsubscribeConfig(pattern, options, callback);
-    }
-
-    unsubscribeConfig(pattern, options, callback) {
-        this.unsubscribeConfigForClient(this.callbackSubscriptionClient, pattern, options, callback);
-    }*/
-
-    // needed by server
-    _unsubscribeConfigForClient(client, pattern, _options, callback) {
-        this.handleUnsubscribe(client, 'objects', pattern);
-        // ignore options => unsubscribe may everyone
         typeof callback === 'function' && setImmediate(() => callback());
     }
 
@@ -1580,507 +819,69 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             options = null;
         }
 
-        //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-        //    if (err) {
-        //        typeof callback === 'function' && setImmediate(() => callback(err));
-        //    } else {
-        return this._unsubscribeConfigForClient(client, pattern, options, callback);
-        //    }
-        //});
+        this.handleUnsubscribe(client, 'objects', pattern); // ignore options => unsubscribe may everyone
 
+        typeof callback === 'function' && setImmediate(() => callback());
     }
 
-    /*
-    _chownObject(pattern, options, callback) {
-        this.getConfigKeys(pattern, options, (err, keys) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-                return;
-            }
-            const list = [];
-            for (let k = 0; k < keys.length; k++) {
-                if (!utils.checkObject(this.dataset[keys[k]], options, utils.CONSTS.ACCESS_WRITE)) {
-                    continue;
-                }
-                if (!this.dataset[keys[k]].acl) {
-                    this.dataset[keys[k]].acl = {
-                        owner:      (this.defaultNewAcl && this.defaultNewAcl.owner)      || utils.CONSTS.SYSTEM_ADMIN_USER,
-                        ownerGroup: (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || utils.CONSTS.SYSTEM_ADMIN_GROUP,
-                        object:     (this.defaultNewAcl && this.defaultNewAcl.object)     || (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_READ | utils.CONSTS.ACCESS_EVERY_READ) // '0644'
-                    };
-                    if (this.dataset[keys[k]].type === 'state') {
-                        this.dataset[keys[k]].acl.state = (this.defaultNewAcl && this.defaultNewAcl.state) || (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_READ | utils.CONSTS.ACCESS_EVERY_READ); // '0644'
-                    }
-                }
-                this.dataset[keys[k]].acl.owner      = options.owner;
-                this.dataset[keys[k]].acl.ownerGroup = options.ownerGroup;
-                list.push(deepClone(this.dataset[keys[k]]));
-            }
-            typeof callback === 'function' && setImmediate(() => callback(null, list));
-            if (!this.stateTimer) {
-                this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
-            }
-        });
-    }
-    chownObject(pattern, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        options = options || {};
-        options.acl = null;
-
-        if (typeof options !== 'object') {
-            options = {owner: options};
-        }
-
-        if (!options.ownerGroup && options.group) {
-            options.ownerGroup = options.group;
-        }
-        if (!options.owner && options.user)  {
-            options.owner = options.user;
-        }
-
-        if (!options.owner) {
-            this.log.error(this.namespace + ' user is not defined');
-            typeof callback === 'function' && setImmediate(() => callback('invalid parameter'));
-            return;
-        }
-
-        if (!options.ownerGroup) {
-            // get user group
-            this.getUserGroup(options.owner, (_user, groups) => {
-                if (!groups || !groups[0]) {
-                    typeof callback === 'function' && setImmediate(() => callback('user "' + options.owner + '" belongs to no group'));
-                    return;
-                } else {
-                    options.ownerGroup = groups[0];
-                }
-                this.chownObject(pattern, options, callback);
-            });
-            return;
-        }
-
-        utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                if (!options.acl.object || !options.acl.object.write) {
-                    typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-                } else {
-                    return this._chownObject(pattern, options, callback);
-                }
-            }
-        });
-    }*/
-
-    /*
-    _chmodObject(pattern, options, callback) {
-        this.getConfigKeys(pattern, options, (err, keys) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-                return;
-            }
-            const list = [];
-            for (let k = 0; k < keys.length; k++) {
-                if (!utils.checkObject(this.dataset[keys[k]], options, utils.CONSTS.ACCESS_WRITE)) {
-                    continue;
-                }
-                if (!this.dataset[keys[k]].acl) {
-                    this.dataset[keys[k]].acl = {
-                        owner:      (this.defaultNewAcl && this.defaultNewAcl.owner)      || utils.CONSTS.SYSTEM_ADMIN_USER,
-                        ownerGroup: (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || utils.CONSTS.SYSTEM_ADMIN_GROUP,
-                        object:     (this.defaultNewAcl && this.defaultNewAcl.object)     || (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_READ | utils.CONSTS.ACCESS_EVERY_READ) // '0644'
-                    };
-                    if (this.dataset[keys[k]].type === 'state') {
-                        this.dataset[keys[k]].acl.state = (this.defaultNewAcl && this.defaultNewAcl.state) || (utils.CONSTS.ACCESS_USER_RW | utils.CONSTS.ACCESS_GROUP_READ | utils.CONSTS.ACCESS_EVERY_READ); // '0644'
-                    }
-                }
-                if (options.object !== undefined) {
-                    this.dataset[keys[k]].acl.object = options.object;
-                }
-                if (options.state  !== undefined) {
-                    this.dataset[keys[k]].acl.state  = options.state;
-                }
-                list.push(deepClone(this.dataset[keys[k]]));
-            }
-            typeof callback === 'function' && setImmediate(() => callback(null, list));
-            if (!this.stateTimer) {
-                this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
-            }
-        });
-    }
-    chmodObject(pattern, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-
-        options = options || {};
-        options.acl = null;
-
-        if (typeof options !== 'object') {
-            options = {object: options};
-        }
-
-        if (options.mode && !options.object) {
-            options.object = options.mode;
-        }
-
-        if (options.object === undefined) {
-            this.log.error(this.namespace + ' mode is not defined');
-            typeof callback === 'function' && setImmediate(() => callback('invalid parameter'));
-            return;
-        } else if (typeof options.mode === 'string') {
-            options.mode = parseInt(options.mode, 16);
-        }
-
-        utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                if (!options.acl.file.write) {
-                    typeof callback === 'function' && setImmediate(() => callback(utils.ERRORS.ERROR_PERMISSION));
-                } else {
-                    return this._chmodObject(pattern, options, callback);
-                }
-            }
-        });
-    }*/
-
-    // needed by server
-    _getObject(id, _options, callback) {
-        const obj = this.dataset[id];
-        typeof callback === 'function' && setImmediate(() => callback(null, obj));
-    }
     // needed by server
     getObject(id, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
         }
-        /*if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.getObject(id, options, (err, obj) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(obj);
-                    }
-                });
-            });
-        }*/
 
-        if (typeof callback === 'function') {
-            /*if (options && options.acl) {
-                options.acl = null;
-            }*/
-            //utils.checkObjectRights(this, id, this.dataset[id], options, utils.CONSTS.ACCESS_READ, (err, options) => {
-            //    if (err) {
-            //        return tools.maybeCallbackWithError(callback, err);
-            //    } else {
-            return this._getObject(id, options, callback);
-            //    }
-            //});
-        }
+        typeof callback === 'function' && setImmediate(() => callback(null, this.dataset[id]));
     }
 
-    // check later
-    /*getObjectAsync(id, options) {
-        return new Promise((resolve, reject) => {
-            this.getObject(id, options, (err, obj) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(obj);
-                }
-            });
-        });
-    }*/
-
     // needed by server
-    _getKeys(pattern, options, callback, _dontModify) {
+    getKeys(pattern, options, callback, _dontModify) {
+        if (typeof options === 'function') {
+            callback = options;
+            options = null;
+        }
+
+        if (typeof callback !== 'function') { // no need to do anything if no callback is there to return it
+            return;
+        }
+
         const r = new RegExp(tools.pattern2RegEx(pattern));
         const result = [];
         for (const id of Object.keys(this.dataset)) {
-            if (r.test(id) /*&& utils.checkObject(this.dataset[id], options, utils.CONSTS.ACCESS_LIST)*/) {
+            if (r.test(id)) {
                 result.push(id);
             }
         }
         result.sort();
-        typeof callback === 'function' && setImmediate(() => callback(null, result));
+        setImmediate(() => callback(null, result));
     }
+
     // needed by server
-    getKeys(pattern, options, callback, dontModify) {
+    getObjects(keys, options, callback, _dontModify) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
         }
 
-        /*if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.getKeys(pattern, options, (err, obj) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(obj);
-                    }
-                }, dontModify);
-            });
-        }*/
+        if (typeof callback !== 'function') { // no need to do anything if no callback is there to return it
+            return;
+        }
 
-        /*if (options && options.acl) {
-            options.acl = null;
-        }*/
-        //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-        //    if (err) {
-        //        typeof callback === 'function' && setImmediate(() => callback(err));
-        //    } else {
-        return this._getKeys(pattern, options, callback, dontModify);
-        //    }
-        //});
-    }
-
-    /*
-    getConfigKeys(pattern, options, callback, dontModify) {
-        return this.getKeys(pattern, options, callback, dontModify);
-    }*/
-
-    // needed by server
-    _getObjects(keys, options, callback, _dontModify) {
         if (!keys) {
-            typeof callback === 'function' && setImmediate(() => callback('no keys', null));
+            setImmediate(() => callback('no keys', null));
             return;
         }
         if (!keys.length) {
-            typeof callback === 'function' && setImmediate(() => callback(null, []));
+            setImmediate(() => callback(null, []));
             return;
         }
+
         const result = [];
         for (let i = 0; i < keys.length; i++) {
-            //if (utils.checkObject(this.dataset[keys[i]], options, utils.CONSTS.ACCESS_READ)) {
             result.push(this.dataset[keys[i]]);
-            //} else {
-            //    result.push({error: utils.ERRORS.ERROR_PERMISSION});
-            //}
         }
-        typeof callback === 'function' && setImmediate(() => callback(null, result));
+        setImmediate(() => callback(null, result));
     }
-    // needed by server
-    getObjects(keys, options, callback, dontModify) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        /*if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.getObjects(keys, options, (err, objs) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(objs);
-                    }
-                }, dontModify);
-            });
-        }*/
-
-        /*if (options && options.acl) {
-            options.acl = null;
-        }*/
-        if (typeof callback === 'function') {
-            //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_READ, (err, options) => {
-            //    if (err) {
-            //        setImmediate(() => callback(err));
-            //    } else {
-            return this._getObjects(keys, options, callback, dontModify);
-            //    }
-            //});
-        }
-    }
-
-    /*
-    _getObjectsByPattern(pattern, options, callback) {
-        const r = new RegExp(tools.pattern2RegEx(pattern));
-        const keys = [];
-        for (const id of Object.keys(this.dataset)) {
-            if (r.test(id) && utils.checkObject(this.dataset[id], options, utils.CONSTS.ACCESS_READ)) {
-                keys.push(id);
-            }
-        }
-        keys.sort();
-        const result = [];
-        for (let i = 0; i < keys.length; i++) {
-            result.push(deepClone(this.dataset[keys[i]]));
-        }
-        typeof callback === 'function' && setImmediate(() => callback(null, result));
-    }
-    getObjectsByPattern(pattern, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.getObjectsByPattern(pattern, options, (err, obj) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(obj);
-                    }
-                });
-            });
-        }
-        if (options && options.acl) {
-            options.acl = null;
-        }
-        if (typeof callback === 'function') {
-            utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_READ, (err, options) => {
-                if (err) {
-                    setImmediate(() => callback(err));
-                } else {
-                    return this._getObjectsByPattern(pattern, options, callback);
-                }
-            });
-        }
-    }*/
-
-    /*
-    _setObject(id, obj, options, callback) {
-        if (!id || utils.regCheckId.test(id)) {
-            if (typeof callback === 'function') {
-                callback(`Invalid ID: ${id}`);
-            }
-            return;
-        }
-
-        if (!obj) {
-            this.log.error(this.namespace + ' setObject: Argument object is null');
-            typeof callback === 'function' && setImmediate(() => callback('obj is null'));
-            return;
-        }
-
-        // make a copy of the object
-        obj = deepClone(obj);
-
-        obj._id = id;
-
-        // special case for system.config to update defaultNewAcl if changed
-        if (id === 'system.config' &&
-            obj.common &&
-            this.dataset[id] &&
-            this.dataset[id].common &&
-            !isDeepStrictEqual(obj.common.defaultNewAcl, this.dataset[id].common.defaultNewAcl)) {
-            this.dataset[id] = obj;
-            return this.setDefaultAcl(() => this.setObject(id, obj, options, callback));
-        }
-
-        if (!tools.checkNonEditable(this.dataset[id], obj)) {
-            typeof callback === 'function' && setImmediate(() => callback('Invalid password for update of vendor information'));
-            return;
-        }
-
-        // do not delete common settings, like "history" or "mobile". It can be erased only with "null"
-        if (this.dataset[id] && this.dataset[id].common) {
-            this.preserveSettings.forEach(commonSetting => {
-                // special case if "custom"
-                if (commonSetting === 'custom') {
-                    // we had broken objects where common.custom was a "non-object" ... check and fix them here, no warning because users will most likely have no idea how to deal with it
-                    if (this.dataset[id].common.custom !== undefined && this.dataset[id].common.custom !== null && !tools.isObject(this.dataset[id].common.custom)) {
-                        delete this.dataset[id].common.custom;
-                    }
-                    // also remove invalid data from new objects ... should not happen because adapter.js checks too
-                    if (obj.common && obj.common.custom !== undefined && obj.common.custom !== null && !tools.isObject(obj.common.custom)) {
-                        delete obj.common.custom;
-                    }
-
-                    if (!this.dataset[id].common.custom) {
-                        // do nothing
-                    } else if ((!obj.common || !obj.common.custom) && this.dataset[id].common.custom) {
-                        obj.common = obj.common || {};
-                        obj.common.custom = this.dataset[id].common.custom;
-                    } else if (obj.common && obj.common.custom && this.dataset[id].common.custom) {
-                        // merge together
-                        Object.keys(this.dataset[id].common.custom).forEach(attr => {
-                            if (obj.common.custom[attr] === null) {
-                                delete obj.common.custom[attr];
-                            } else if (obj.common.custom[attr] === undefined) {
-                                obj.common.custom[attr] = this.dataset[id].common.custom[attr];
-                            }
-                        });
-                    }
-                    // remove custom if no one attribute inside
-                    if (obj.common && obj.common.custom) {
-                        Object.keys(obj.common.custom).forEach(attr => {
-                            if (obj.common.custom[attr] === null) {
-                                delete obj.common.custom[attr];
-                            }
-                        });
-                        if (!Object.keys(obj.common.custom).length) {
-                            delete obj.common.custom;
-                        }
-                    }
-                } else {
-                    // remove settings if desired
-                    if (obj.common && obj.common[commonSetting] === null) {
-                        delete obj.common[commonSetting];
-                    } else
-                    // if old setting present and new setting is absent
-                    if (this.dataset[id].common[commonSetting] !== undefined && (!obj.common || obj.common[commonSetting] === undefined)) {
-                        obj.common = obj.common || {};
-                        obj.common[commonSetting] = this.dataset[id].common[commonSetting];
-                    }
-                }
-            });
-        }
-
-        if (obj.common && obj.common.alias && obj.common.alias.id) {
-            if (typeof obj.common.alias.id === 'object') {
-                if (typeof obj.common.alias.id.write !== 'string' || typeof obj.common.alias.id.read !== 'string') {
-                    return typeof callback === 'function' && callback('Invalid alias ID');
-                }
-
-                if (obj.common.alias.id.write.startsWith('alias.') || obj.common.alias.id.read.startsWith('alias.')) {
-                    return typeof callback === 'function' && callback('Cannot make alias on alias');
-                }
-            } else {
-                if (typeof obj.common.alias.id !== 'string') {
-                    return typeof callback === 'function' && callback('Invalid alias ID');
-                }
-
-                if (obj.common.alias.id.startsWith('alias.')) {
-                    return typeof callback === 'function' && callback('Cannot make alias on alias');
-                }
-            }
-        }
-
-        if (this.dataset[id] && this.dataset[id].acl && !obj.acl) {
-            obj.acl = this.dataset[id].acl;
-        }
-
-        // add user default rights if no acl provided
-        if (this.defaultNewAcl && !obj.acl) {
-            obj.acl = deepClone(this.defaultNewAcl);
-            delete obj.acl.file;
-            if (obj.type !== 'state') {
-                delete obj.acl.state;
-            }
-            // take the owner as current user, but if admin we keep default
-            if (options.user && options.user !== utils.CONSTS.SYSTEM_ADMIN_USER) {
-                obj.acl.owner = options.user;
-            }
-            // take the current group as owner if given, but if admin we keep default
-            if (options.group && options.group !== utils.CONSTS.SYSTEM_ADMIN_GROUP) {
-                obj.acl.ownerGroup = options.group;
-            }
-            return this._setObjectDirect(id, obj, callback);
-        }
-
-        if (this.defaultNewAcl && obj.acl && !obj.acl.ownerGroup && options.group) {
-            obj.acl.ownerGroup = options.group;
-        }
-
-        this._setObjectDirect(id, obj, callback);
-    }*/
 
     // needed by server
     _setObjectDirect(id, obj, callback) {
@@ -2098,130 +899,48 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         this.stateTimer = this.stateTimer || setTimeout(() => this.saveState(), this.writeFileInterval);
     }
 
-    /*/**
-     * set a new or update object
-     *
-     * This function writes the object into DB
-     *
-     * @param {string} id ID of the object
-     * @param {object} obj
-     * @param {object} options optional options for access control are optional
-     * @param {function} callback return function
-     */
-    /*
-    setObject(id, obj, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.setObject(id, obj, options, (err, res) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(res);
-                    }
-                });
-            });
-        }
-        if (options && options.acl) {
-            options.acl = null;
-        }
-
-        utils.checkObjectRights(this, id, this.dataset[id], options, utils.CONSTS.ACCESS_WRITE, err => {
-            // do not use options from checkObjectRights because this will mess up configured default acl
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                return this._setObject(id, obj, options || {}, callback);
-            }
-        });
-    }
-
-    setObjectAsync(id, obj, options) {
-        return new Promise((resolve, reject) => {
-            this.setObject(id, obj, options, (err, res) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(res);
-                }
-            });
-        });
-    }*/
-
-    // needed by server
-    _delObject(id, _options, callback) {
-        if (this.dataset[id]) {
-            if (this.dataset[id].common && this.dataset[id].common.dontDelete) {
-                typeof callback === 'function' && setImmediate(() => callback('Object is marked as non deletable'));
-                return;
-            }
-
-            delete this.dataset[id];
-
-            // object has been deleted -> remove from cached meta if there
-            if (this.existingMetaObjects[id]) {
-                this.existingMetaObjects[id] = false;
-            }
-
-            typeof callback === 'function' && setImmediate(() => callback(null));
-
-            setImmediate(() => this.publishAll('objects', id, null));
-
-            if (!this.stateTimer) {
-                this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
-            }
-        } else {
-            return tools.maybeCallbackWithError(callback, utils.ERRORS.ERROR_NOT_FOUND);
-        }
-    }
     // needed by server
     delObject(id, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
         }
-        /*if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.delObject(id, options, err => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve();
-                    }
-                });
-            });
-        }*/
+        if (!this.dataset[id]) {
+            return tools.maybeCallbackWithError(callback, utils.ERRORS.ERROR_NOT_FOUND);
+        }
 
-        /*if (options && options.acl) {
-            options.acl = null;
-        }*/
-        //utils.checkObjectRights(this, id, this.dataset[id], options, utils.CONSTS.ACCESS_DELETE, (err, options) => {
-        //    if (err) {
-        //        typeof callback === 'function' && setImmediate(() => callback(err));
-        //    } else {
-        return this._delObject(id, options, callback);
-        //    }
-        //});
+        if (this.dataset[id].common && this.dataset[id].common.dontDelete) {
+            typeof callback === 'function' && setImmediate(() => callback('Object is marked as non deletable'));
+            return;
+        }
+
+        delete this.dataset[id];
+
+        // object has been deleted -> remove from cached meta if there
+        if (this.existingMetaObjects[id]) {
+            this.existingMetaObjects[id] = false;
+        }
+
+        typeof callback === 'function' && setImmediate(() => callback(null));
+
+        setImmediate(() => this.publishAll('objects', id, null));
+
+        if (!this.stateTimer) {
+            this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
+        }
     }
 
-    /*
-    delObjectAsync(id, options) {
-        return new Promise((resolve, reject) => {
-            this.delObject(id, options, err => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            });
-        });
-    }*/
-
     // internal functionality
-    _applyViewFunc(func, params, options, callback) {
+    _applyView(func, params, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+            options = null;
+        }
+
+        if (typeof callback !== 'function') { // no need to do anything if no callback is there to return it
+            return;
+        }
+
         const result = {
             rows: []
         };
@@ -2243,14 +962,10 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 }
             }
             if (this.dataset[id]) {
-                /*if (!utils.checkObject(this.dataset[id], options, utils.CONSTS.ACCESS_READ)) {
-                    continue;
-                }*/
                 try {
                     f(this.dataset[id]);
                 } catch (e) {
                     this.log.warn('Cannot execute map: ' + e.message);
-
                 }
             }
         }
@@ -2269,44 +984,20 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             }
         }
 
-        typeof callback === 'function' && setImmediate(() => callback(null, result));
+        setImmediate(() => callback(null, result));
     }
 
-    // internal functionality
-    _applyView(func, params, options, callback) {
+    // needed by server
+    getObjectView(design, search, params, options, callback) {
         if (typeof options === 'function') {
             callback = options;
             options = null;
         }
-        /*if (!callback) {
-            return new Promise((resolve, reject) => {
-                this._applyView(func, params, options, (err, obj) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(obj);
-                    }
-                });
-            });
-        }*/
 
-        /*if (options && options.acl) {
-            options.acl = null;
-        }*/
-
-        if (typeof callback === 'function') {
-            //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-            //    if (err) {
-            //        setImmediate(() => callback(err));
-            //    } else {
-            return this._applyViewFunc(func, params, options, callback);
-            //    }
-            //});
+        if (typeof callback !== 'function') { // no need to do anything if no callback is there to return it
+            return;
         }
-    }
 
-    // needed by server
-    _getObjectView(design, search, params, options, callback) {
         if (this.dataset['_design/' + design]) {
             if (this.dataset[`_design/${design}`].views && this.dataset['_design/' + design].views[search]) {
                 this._applyView(this.dataset[`_design/${design}`].views[search], params, options, callback);
@@ -2319,354 +1010,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             setImmediate(() => callback(new Error(`Cannot find view "${design}"`)));
         }
     }
-    // needed by server
-    getObjectView(design, search, params, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        /*if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.getObjectView(design, search, params, options, (err, obj) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(obj);
-                    }
-                });
-            });
-        }*/
-
-        /*if (options && options.acl) {
-            options.acl = null;
-        }*/
-
-        if (typeof callback === 'function') {
-            //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-            //    if (err) {
-            //        setImmediate(() => callback(err));
-            //    } else {
-            return this._getObjectView(design, search, params, options, callback);
-            //    }
-            //});
-        }
-    }
-
-    /*/** Async version of getObjectView **/
-    /*
-    getObjectViewAsync(design, search, params, options) {
-        return new Promise((resolve, reject) => {
-            this.getObjectView(design, search, params, options, (err, res) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(res);
-                }
-            });
-        });
-    }*/
-
-    /*
-    _getObjectList(params, options, callback) {
-        // return rows with id and doc
-        const result = {
-            rows: []
-        };
-
-        for (const id of Object.keys(this.dataset)) {
-            if (!utils.checkObject(this.dataset[id], options, utils.CONSTS.ACCESS_READ)) {
-                continue;
-            }
-            if (params) {
-                if (params.startkey && id < params.startkey) {
-                    continue;
-                }
-                if (params.endkey   && id > params.endkey)   {
-                    continue;
-                }
-                if (!params.include_docs && id[0] === '_')   {
-                    continue;
-                }
-            }
-            const obj = {id: id, value: this.clone(this.dataset[id])};
-            obj.doc = obj.value;
-
-            if (options.sorted) {
-                // insert sorted
-                if (!result.rows.length) {
-                    result.rows.push(obj);
-                } else if (obj.id <= result.rows[0].id) {
-                    result.rows.unshift(obj);
-                } else if (obj.id >= result.rows[result.rows.length - 1].id) {
-                    result.rows.push(obj);
-                } else {
-                    for (let t = 1; t < result.rows.length; t++) {
-                        if (obj.id > result.rows[t - 1].id && obj.id <= result.rows[t].id) {
-                            result.rows.splice(t, 0, obj);
-                            break;
-                        }
-                    }
-                }
-            } else {
-                result.rows.push(obj);
-            }
-        }
-        callback(null, result);
-    }
-    getObjectList(params, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.getObjectList(params, options, (err, obj) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(obj);
-                    }
-                });
-            });
-        }
-
-        if (options && options.acl) {
-            options.acl = null;
-        }
-
-        if (typeof callback === 'function') {
-            utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-                if (err) {
-                    setImmediate(() => callback(err));
-                } else {
-                    return this._getObjectList(params, options, callback);
-                }
-            });
-        }
-    }
-
-    getObjectListAsync(params, options) {
-        return new Promise((resolve, reject) => {
-            this.getObjectList(params, options, (err, arr) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(arr);
-                }
-            });
-        });
-    }*/
-
-    /*
-    _extendObject(id, obj, options, callback) {
-        if (!id || utils.regCheckId.test(id)) {
-            typeof callback === 'function' && setImmediate(() => callback(`Invalid ID: ${id}`));
-            return;
-        }
-
-        if (
-            id === 'system.config'
-            && obj && obj.common
-            && this.dataset[id] && this.dataset[id].common
-            && !isDeepStrictEqual(obj.common.defaultNewAcl, this.dataset[id].common.defaultNewAcl)
-        ) {
-            this.dataset[id] = obj;
-            return this.setDefaultAcl(() => this._extendObject(id, obj, options, callback));
-        }
-
-        let oldObj;
-        if (this.dataset[id] && this.dataset[id].nonEdit) {
-            oldObj = deepClone(this.dataset[id]);
-        }
-
-        this.dataset[id] = this.dataset[id] || {};
-        obj = deepClone(obj); // copy here to prevent "sandboxed" objects from JavaScript adapter
-        if (oldObj && oldObj.common && oldObj.common.custom !== undefined && oldObj.common.custom !== null && !tools.isObject(oldObj.common.custom)) {
-            delete oldObj.common.custom;
-        }
-
-        this.dataset[id] = extend(true, this.dataset[id], obj);
-        this.dataset[id]._id = id;
-
-        // extended -> if its now type meta and currently marked as not -> cache
-        if (this.existingMetaObjects[id] === false && this.dataset[id].type === 'meta') {
-            this.existingMetaObjects[id] = true;
-        }
-
-        // add user default rights
-        if (this.defaultNewAcl && !this.dataset[id].acl) {
-            this.dataset[id].acl = deepClone(this.defaultNewAcl);
-            delete this.dataset[id].acl.file;
-            if (this.dataset[id].type !== 'state') {
-                delete this.dataset[id].acl.state;
-            }
-
-            if (options.owner) {
-                this.dataset[id].acl.owner = options.owner;
-
-                if (!options.ownerGroup) {
-                    this.dataset[id].acl.ownerGroup = null;
-                    this.getUserGroup(options.owner, (_user, groups) => {
-                        if (!groups || !groups[0]) {
-                            options.ownerGroup = (this.defaultNewAcl && this.defaultNewAcl.ownerGroup) || utils.CONSTS.SYSTEM_ADMIN_GROUP;
-                        } else {
-                            options.ownerGroup = groups[0];
-                        }
-                        this._extendObject(id, obj, options, callback);
-                    });
-                    return;
-                }
-            }
-        }
-
-        if (this.defaultNewAcl && options.ownerGroup && this.dataset[id].acl && !this.dataset[id].acl.ownerGroup) {
-            this.dataset[id].acl.ownerGroup = options.ownerGroup;
-        }
-
-        if (oldObj && !tools.checkNonEditable(oldObj, this.dataset[id])) {
-            return typeof callback === 'function' && setImmediate(() =>
-                callback('Invalid password for update of vendor information'));
-        }
-
-        typeof callback === 'function' && setImmediate(obj =>
-            callback(null, obj, id), {id: id, value: this.dataset[id]});
-
-        setImmediate(obj => this.publishAll('objects', id, obj), this.dataset[id]);
-
-        this.stateTimer = this.stateTimer || setTimeout(() => this.saveState(), this.writeFileInterval);
-    }
-    extendObject(id, obj, options, callback) {
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.extendObject(id, obj, options, (err, obj) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(obj);
-                    }
-                });
-            });
-        }
-
-        if (options && options.acl) {
-            options.acl = null;
-        }
-
-        utils.checkObjectRights(this, id, this.dataset[id], options, utils.CONSTS.ACCESS_WRITE, (err, options) => {
-            if (err) {
-                typeof callback === 'function' && setImmediate(() => callback(err));
-            } else {
-                return this._extendObject(id, obj, options, callback);
-            }
-        });
-    }
-
-    extendObjectAsync(id, obj, options) {
-        return new Promise((resolve, reject) => {
-            this.extendObject(id, obj, options, err => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve();
-                }
-            });
-        });
-    }*/
-
-    /*
-    setConfig(id, obj, options, callback) {
-        return this.setObject(id, obj, options, callback);
-    }
-
-    delConfig(id, options, callback) {
-        return this.delObject(id, options, callback);
-    }
-
-    getConfig(id, options, callback) {
-        return this.getObject(id, options, callback);
-    }
-
-    getConfigs(keys, options, callback, dontModify) {
-        return this.getObjects(keys, options, callback, dontModify);
-    }*/
-
-    /*
-    _findObject(idOrName, type, options, callback) {
-        if (!this.dataset) {
-            typeof callback === 'function' && setImmediate(() => callback('Not implemented'));
-            return;
-        }
-
-        // Assume it is ID
-        if (this.dataset[idOrName] && (!type || (this.dataset[idOrName].common && this.dataset[idOrName].common.type === type))) {
-            typeof callback === 'function' && setImmediate(objName => callback(null, idOrName, objName), this.dataset[idOrName].common.name);
-        } else {
-            // Assume it is name
-            for (const id of Object.keys(this.dataset)) {
-                if (!utils.checkObject(this.dataset[id], options, utils.CONSTS.ACCESS_READ)) {
-                    continue;
-                }
-                if (this.dataset[id].common &&
-                    this.dataset[id].common.name === idOrName &&
-                    (!type || (this.dataset[id].common && this.dataset[id].common.type === type))) {
-                    typeof callback === 'function' && setImmediate(() => callback(null, id, idOrName));
-                    return;
-                }
-            }
-            typeof callback === 'function' && setImmediate(() => callback(null, null, idOrName));
-        }
-    }
-    findObject(idOrName, type, options, callback) {
-        if (typeof type === 'function') {
-            callback = type;
-            options = null;
-            type = null;
-        }
-        if (typeof options === 'function') {
-            callback = options;
-            options = null;
-        }
-        if (!callback) {
-            return new Promise((resolve, reject) => {
-                this.findObject(idOrName, type, options, (err, id, _idOrName) => {
-                    if (err) {
-                        reject(err);
-                    } else {
-                        resolve(id);
-                    }
-                });
-            });
-        }
-
-        if (options && options.acl) {
-            options.acl = null;
-        }
-
-        if (typeof callback === 'function') {
-            utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
-                if (err) {
-                    setImmediate(() => callback(err));
-                } else {
-                    return this._findObject(idOrName, type, options, callback);
-                }
-            });
-        }
-    }*/
-
-    /*// can be called only from js-controller
-    addPreserveSettings(settings) {
-        if (!Array.isArray(settings)) {
-            settings = [settings];
-        }
-
-        for (let s = 0; s < settings.length; s++) {
-            !this.preserveSettings.includes(settings[s]) && this.preserveSettings.push(settings[s]);
-        }
-    }*/
 
     // special functionality
     _destroyDB(_options, callback) {

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -898,7 +898,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
     }
 
     // Destructor of the class. Called by shutting down.
-    destroy() {
+    async destroy() {
         super.destroy();
 
         this._saveFileSettings(true);

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -1750,7 +1750,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
     // needed by server
     _getObject(id, _options, callback) {
-        const obj = this.clone(this.dataset[id]);
+        const obj = this.dataset[id];
         typeof callback === 'function' && setImmediate(() => callback(null, obj));
     }
     // needed by server
@@ -1859,7 +1859,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         const result = [];
         for (let i = 0; i < keys.length; i++) {
             //if (utils.checkObject(this.dataset[keys[i]], options, utils.CONSTS.ACCESS_READ)) {
-            result.push(this.clone(this.dataset[keys[i]]));
+            result.push(this.dataset[keys[i]]);
             //} else {
             //    result.push({error: utils.ERRORS.ERROR_PERMISSION});
             //}
@@ -2084,7 +2084,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
     // needed by server
     _setObjectDirect(id, obj, callback) {
-        this.dataset[id] = deepClone(obj);
+        this.dataset[id] = obj;
 
         // object updated -> if type changed to meta -> cache
         if (this.dataset[id].type === 'meta' && this.existingMetaObjects[id] === false) {

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -379,6 +379,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
     // needed by server
     _writeFile(id, name, data, options, callback) {
+        options = options || {};
         try {
             try {
                 if (!fs.existsSync(this.objectsDir)) {
@@ -493,6 +494,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
     // needed by server
     _readFile(id, name, options, callback) {
+        options = options || {};
         try {
             this.loadFileSettings(id);
 
@@ -786,9 +788,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             callback = options;
             options  = null;
         }
-        if (options && options.acl) {
+        /*if (options && options.acl) {
             options.acl = null;
-        }
+        }*/
         const _path = utils.sanitizePath(id, name, callback);
         if (!_path) {
             return;
@@ -816,6 +818,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
 
     // needed by server
     _readDir(id, name, options, callback) {
+        options = options || {};
         // Find all files and directories starts with name
         const _files = [];
 
@@ -1011,9 +1014,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             callback = options;
             options = null;
         }
-        if (options && options.acl) {
+        /*if (options && options.acl) {
             options.acl = null;
-        }
+        }*/
         const _path = utils.sanitizePath(id, oldName, callback);
         if (!_path) {
             return;
@@ -1769,9 +1772,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }*/
 
         if (typeof callback === 'function') {
-            if (options && options.acl) {
+            /*if (options && options.acl) {
                 options.acl = null;
-            }
+            }*/
             //utils.checkObjectRights(this, id, this.dataset[id], options, utils.CONSTS.ACCESS_READ, (err, options) => {
             //    if (err) {
             //        return tools.maybeCallbackWithError(callback, err);
@@ -1800,7 +1803,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         const r = new RegExp(tools.pattern2RegEx(pattern));
         const result = [];
         for (const id of Object.keys(this.dataset)) {
-            if (r.test(id) && utils.checkObject(this.dataset[id], options, utils.CONSTS.ACCESS_LIST)) {
+            if (r.test(id) /*&& utils.checkObject(this.dataset[id], options, utils.CONSTS.ACCESS_LIST)*/) {
                 result.push(id);
             }
         }
@@ -1826,9 +1829,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             });
         }*/
 
-        if (options && options.acl) {
+        /*if (options && options.acl) {
             options.acl = null;
-        }
+        }*/
         //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
         //    if (err) {
         //        typeof callback === 'function' && setImmediate(() => callback(err));
@@ -1881,9 +1884,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             });
         }*/
 
-        if (options && options.acl) {
+        /*if (options && options.acl) {
             options.acl = null;
-        }
+        }*/
         if (typeof callback === 'function') {
             //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_READ, (err, options) => {
             //    if (err) {
@@ -2192,9 +2195,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             });
         }*/
 
-        if (options && options.acl) {
+        /*if (options && options.acl) {
             options.acl = null;
-        }
+        }*/
         //utils.checkObjectRights(this, id, this.dataset[id], options, utils.CONSTS.ACCESS_DELETE, (err, options) => {
         //    if (err) {
         //        typeof callback === 'function' && setImmediate(() => callback(err));
@@ -2287,9 +2290,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             });
         }*/
 
-        if (options && options.acl) {
+        /*if (options && options.acl) {
             options.acl = null;
-        }
+        }*/
 
         if (typeof callback === 'function') {
             //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
@@ -2334,9 +2337,9 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             });
         }*/
 
-        if (options && options.acl) {
+        /*if (options && options.acl) {
             options.acl = null;
-        }
+        }*/
 
         if (typeof callback === 'function') {
             //utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, (err, options) => {
@@ -2684,7 +2687,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             callback = options;
             options = null;
         }
-        options = options || {};
 
         if (!callback) {
             return new Promise((resolve, reject) => {
@@ -2698,6 +2700,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
             });
         }
 
+        options = options || {};
         options.acl = null;
 
         utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_WRITE, (err, options) => {

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -539,7 +539,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
         }
         // Store dir description
         if (changed) {
-            setImmediate(() => this._saveFileSettings(id));
+            this._saveFileSettings(id, true);
         }
     }
 
@@ -707,7 +707,7 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 this.files[id][name.replace(oldName, newName)] = data;
             }
         });
-        this._saveFileSettings(id);
+        this._saveFileSettings(id, true);
     }
 
     // internal functionality

--- a/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemFileDB.js
@@ -577,7 +577,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 }
             }
         }
-        this.log.debug('fileOptions: ' + JSON.stringify(_files));
 
         const location = path.join(this.objectsDir, id, name);
         if (fs.existsSync(location)) {
@@ -588,7 +587,6 @@ class ObjectsInMemoryFileDB extends InMemoryFileDB {
                 }
                 if (dirFiles[i] !== '_data.json' && _files.indexOf(dirFiles[i]) === -1) {
                     _files.push(dirFiles[i]);
-                    this.log.debug('Add: ' + dirFiles[i]);
                 }
             }
         } else {

--- a/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
@@ -55,16 +55,6 @@ class ObjectsInMemoryServerClass extends ObjectsInRedisClient {
     async dirExists(id, name, options) {
         return this.objectsServer.dirExists(id, name, options);
     }
-
-    // Try to increase performance by directly calling server code for real logic
-    async _setObject(id, obj, options, callback) {
-        return this.objectsServer._setObjectDirect(id, obj, callback);
-    }
-
-    async _getObject(id, options, callback) {
-        return this.objectsServer._getObject(id, options, callback);
-    }
-
 }
 
 module.exports = ObjectsInMemoryServerClass;

--- a/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
@@ -55,6 +55,16 @@ class ObjectsInMemoryServerClass extends ObjectsInRedisClient {
     async dirExists(id, name, options) {
         return this.objectsServer.dirExists(id, name, options);
     }
+
+    // Try to increase performance by directly calling server code for real logic
+    async _setObject(id, obj, options, callback) {
+        return this.objectsServer._setObjectDirect(id, obj, callback);
+    }
+
+    async _getObject(id, options, callback) {
+        return this.objectsServer._getObject(id, options, callback);
+    }
+
 }
 
 module.exports = ObjectsInMemoryServerClass;

--- a/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
@@ -37,7 +37,7 @@ class ObjectsInMemoryServerClass extends ObjectsInRedisClient {
 
     async destroy() {
         await super.destroy(); // destroy client first
-        this.objectsServer.destroy(); // server afterwards too
+        await this.objectsServer.destroy(); // server afterwards too
     }
 
     getStatus() {

--- a/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
@@ -44,16 +44,12 @@ class ObjectsInMemoryServerClass extends ObjectsInRedisClient {
         return this.objectsServer.getStatus(); // return Status as Server
     }
 
-    destroyDB(options, callback) {
-        return this.objectsServer.destroyDB(options, callback);
+    syncFileDirectory(limitId) {
+        return this.objectsServer.syncFileDirectory(limitId);
     }
 
-    syncFileDirectory(limitId, callback) {
-        return this.objectsServer.syncFileDirectory(limitId, callback);
-    }
-
-    async dirExists(id, name, options) {
-        return this.objectsServer.dirExists(id, name, options);
+    dirExists(id, name) {
+        return this.objectsServer.dirExists(id, name);
     }
 }
 

--- a/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerClass.js
@@ -1,0 +1,60 @@
+/**
+ *      States DB in memory - Server with Redis protocol
+ *
+ *      Copyright 2013-2020 bluefox <dogafox@gmail.com>
+ *
+ *      MIT License
+ *
+ */
+
+/** @module statesInMemory */
+
+/* jshint -W097 */
+/* jshint strict:false */
+/* jslint node: true */
+'use strict';
+
+const ObjectsInRedisClient = require('@iobroker/db-objects-redis').Client;
+const ObjectsInMemServer = require('./objectsInMemServerRedis');
+
+class ObjectsInMemoryServerClass extends ObjectsInRedisClient {
+
+    constructor(settings) {
+        settings.autoConnect = false; // delay Client connection to when we need it
+        super(settings);
+
+        const serverSettings = {
+            namespace: settings.namespace + '-Server',
+            connection: settings.connection,
+            logger: settings.logger,
+            hostname: settings.hostname,
+            connected: () => {
+                this.connectDb(); // now that server is connected also connect client
+            }
+        };
+        this.objectsServer = new ObjectsInMemServer(serverSettings);
+    }
+
+    async destroy() {
+        await super.destroy(); // destroy client first
+        this.objectsServer.destroy(); // server afterwards too
+    }
+
+    getStatus() {
+        return this.objectsServer.getStatus(); // return Status as Server
+    }
+
+    destroyDB(options, callback) {
+        return this.objectsServer.destroyDB(options, callback);
+    }
+
+    syncFileDirectory(limitId, callback) {
+        return this.objectsServer.syncFileDirectory(limitId, callback);
+    }
+
+    async dirExists(id, name, options) {
+        return this.objectsServer.dirExists(id, name, options);
+    }
+}
+
+module.exports = ObjectsInMemoryServerClass;

--- a/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
@@ -738,7 +738,9 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                 }
                 const response = [];
                 let baseName = name;
-                if (!baseName.endsWith('/')) baseName += '/';
+                if (!baseName.endsWith('/')) {
+                    baseName += '/';
+                }
                 res.forEach(arr => {
                     let entryId = id;
                     if (arr.isDir) {

--- a/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
@@ -704,8 +704,8 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
         const {id, namespace, name, isMeta} = this._normalizeId(pattern);
 
         if (namespace === this.namespaceObj) {
-            const result = this._getKeys(id);
-            result.map(val => this.namespaceObj + val);
+            let result = this._getKeys(id);
+            result = result.map(val => this.namespaceObj + val);
             // if scan, we send the cursor as first argument
             handler.sendArray(responseId, isScan ? ['0', result] : result);
         } else if (namespace === this.namespaceFile) {

--- a/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
@@ -756,8 +756,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                     response.push(this.getFileId(entryId, baseName + arr.file, false));
                 });
                 handler.sendArray(responseId, isScan ? ['0', response] : response); // send out file or full db response
-            }
-            else { // such a request should never happen
+            } else { // such a request should never happen
                 handler.sendArray(responseId, isScan ? ['0', []] : []); // send out file or full db response
             }
         } else {

--- a/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
@@ -714,20 +714,20 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                 let res;
                 try {
                     res = this._readDir(id, name);
+                    if (!res || !res.length) {
+                        res = [{
+                            file: '_data.json',
+                            stats: {},
+                            isDir: false,
+                            virtualFile: true,
+                            notExists: true
+                        }];
+                    }
                 } catch (err) {
                     if (!err.toString().endsWith(utils.ERRORS.ERROR_NOT_FOUND)) {
                         return void handler.sendError(responseId, new Error(`ERROR readDir id=${id}: ${err.message}`));
                     }
                     res = [];
-                }
-                if (!res || !res.length) {
-                    res = [{
-                        file: '_data.json',
-                        stats: {},
-                        isDir: false,
-                        virtualFile: true,
-                        notExists: true
-                    }];
                 }
                 const response = [];
                 const baseName = (name || '') + ((!name || !name.length || name.endsWith('/')) ? '' : '/');

--- a/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
@@ -757,6 +757,9 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                 });
                 handler.sendArray(responseId, isScan ? ['0', response] : response); // send out file or full db response
             }
+            else { // such a request should never happen
+                handler.sendArray(responseId, isScan ? ['0', []] : []); // send out file or full db response
+            }
         } else {
             handler.sendError(responseId, new Error(`${isScan ? 'SCAN' : 'KEYS'}-UNSUPPORTED for namespace ${namespace}: Pattern=${pattern}`));
         }

--- a/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
@@ -534,7 +534,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                 try {
                     this._delObject(id);
                 } catch (err) {
-                    return void handler.sendError(responseId, new Error('ERROR _delObject ' + id + ': ' + err.message));
+                    return void handler.sendError(responseId, err);
                 }
                 handler.sendInteger(responseId, 1);
             } else if (namespace === this.namespaceFile) {
@@ -547,7 +547,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
                     try {
                         this._unlink(id, name);
                     } catch (err) {
-                        return void handler.sendError(responseId, new Error(`ERROR unlink id=${id}: ${err}`));
+                        return void handler.sendError(responseId, err);
                     }
                     handler.sendString(responseId, 'OK');
                 }

--- a/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
@@ -82,10 +82,6 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
         });
     }
 
-    /*addPreserveSettings(_settings) {
-        // when Redis is used this is done by objectsInRedis already
-    }*/
-
     /**
      * Separate Namespace from ID and return both
      * @param idWithNamespace ID or Array of IDs containing a redis namespace and the real ID

--- a/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
+++ b/packages/db-objects-file/lib/objects/objectsInMemServerRedis.js
@@ -790,16 +790,17 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
      * Initialize Redis Server
      * @param settings Settings object
      * @private
+     * @return {Promise<void>}
      */
     _initRedisServer(settings) {
-        return /** @type {Promise<void|Error>} */ (new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             if (settings.secure) {
                 reject(new Error('Secure Redis unsupported for File-DB'));
             }
             try {
                 this.server = net.createServer();
                 this.server.on('error', err =>
-                    this.log.info(this.namespace + ' ' + (settings.secure ? 'Secure ' : '') + ' Error inMem-objects listening on port ' + (settings.port || 9001)) + ': ' + err);
+                    this.log.info(`${this.namespace} ${settings.secure ? 'Secure ' : ''} Error inMem-objects listening on port ${settings.port || 9001}: ${err}`));
                 this.server.on('connection', socket => this._initSocket(socket));
 
                 this.server.listen(
@@ -810,7 +811,7 @@ class ObjectsInMemoryServer extends ObjectsInMemoryFileDB {
             } catch (err) {
                 reject(err);
             }
-        }));
+        });
     }
 }
 

--- a/packages/db-objects-redis/index.js
+++ b/packages/db-objects-redis/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-    Client: require('./lib/objects/objectsInRedis.js'),
+    Client: require('./lib/objects/objectsInRedisClient.js'),
     Server: null,
     objectsUtils: require('./lib/objects/objectsUtils.js'),
     getDefaultObjectsPort: host => {

--- a/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
+++ b/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
@@ -62,7 +62,7 @@ class ObjectsInRedisClient {
 
         this.log = tools.getLogger(this.settings.logger);
 
-        if (this.settings.autoConnect === undefined || this.settings.autoConnect) {
+        if (this.settings.autoConnect !== false) {
             this.connectDb();
         }
     }

--- a/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
+++ b/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
@@ -530,7 +530,12 @@ class ObjectsInRedisClient {
                 name = name.replace(/^iobroker.[-\d\w]\/admin\//i, '');
             }
         }
-        const normalized = utils.sanitizePath(id, name);
+        let normalized;
+        try {
+            normalized = utils.sanitizePath(id, name);
+        } catch {
+            // ignore
+        }
         if (!normalized) {
             this.log.debug(this.namespace + ' Invalid file path ' + id + '/' + name);
             return '';

--- a/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
+++ b/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
@@ -534,9 +534,6 @@ class ObjectsInRedisClient {
         try {
             normalized = utils.sanitizePath(id, name);
         } catch {
-            // ignore
-        }
-        if (!normalized) {
             this.log.debug(this.namespace + ' Invalid file path ' + id + '/' + name);
             return '';
         }

--- a/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
+++ b/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
@@ -691,9 +691,9 @@ class ObjectsInRedisClient {
         }
 
         if (!callback) {
-            return new Promise((resolve, reject) =>
+            return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
                 this.writeFile(id, name, data, options, err =>
-                    err ? reject(err) : resolve()));
+                    err ? reject(err) : resolve())));
         }
 
         try {
@@ -726,9 +726,9 @@ class ObjectsInRedisClient {
     }
 
     writeFileAsync(id, name, data, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.writeFile(id, name, data, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     async _readFile(id, name, options, callback, meta) {
@@ -807,7 +807,7 @@ class ObjectsInRedisClient {
         }
 
         try {
-            await new Promise((resolve, reject) => {
+            await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
                 utils.checkObjectRights(this, null, null, options, utils.CONSTS.ACCESS_LIST, err => {
                     if (err) {
                         reject(err);
@@ -815,7 +815,7 @@ class ObjectsInRedisClient {
                         resolve();
                     }
                 });
-            });
+            }));
             const exists = await this.client.exists(this.objNamespace + id);
             return !!exists;
         } catch (e) {
@@ -842,7 +842,7 @@ class ObjectsInRedisClient {
         }
 
         try {
-            await new Promise((resolve, reject) => {
+            await /** @type {Promise<void>} */ (new Promise((resolve, reject) => {
                 this.checkFileRights(id, name, options, utils.CONSTS.ACCESS_READ, err => {
                     if (err) {
                         reject(err);
@@ -850,7 +850,7 @@ class ObjectsInRedisClient {
                         resolve();
                     }
                 });
-            });
+            }));
             id = this.getFileId(id, name, false);
             const exists = await this.client.exists(id);
             return !!exists;
@@ -911,9 +911,9 @@ class ObjectsInRedisClient {
     }
 
     unlinkAsync(id, name, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.unlink(id, name, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     delFile(id, name, options, callback) {
@@ -1262,9 +1262,9 @@ class ObjectsInRedisClient {
     }
 
     renameAsync(id, oldName, newName, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.rename(id, oldName, newName, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     async _touch(id, name, options, callback, meta) {
@@ -1311,9 +1311,9 @@ class ObjectsInRedisClient {
     }
 
     touchAsync(id, name, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.touch(id, name, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     async _rmHelper(keys, callback) {
@@ -1483,9 +1483,9 @@ class ObjectsInRedisClient {
     }
 
     mkdirAsync(id, dirName, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.mkdir(id, dirName, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     async _chownFileHelper(keys, metas, options, callback) {
@@ -1675,31 +1675,30 @@ class ObjectsInRedisClient {
     }
 
     chownFileAsync(id, name, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.chownFile(id, name, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     async _chmodFileHelper(keys, metas, options, callback) {
         if (!keys || !keys.length) {
             return tools.maybeCallback(callback);
-        } else {
-            if (!this.client) {
-                return tools.maybeCallbackWithError(callback, utils.ERRORS.ERROR_DB_CLOSED);
-            }
+        }
+        if (!this.client) {
+            return tools.maybeCallbackWithError(callback, utils.ERRORS.ERROR_DB_CLOSED);
+        }
 
-            for (const i in keys) {
-                const id = keys[i];
-                const meta = metas[i];
-                meta.acl.permissions = options.mode;
-                try {
-                    await this.client.set(id, JSON.stringify(meta));
-                    return tools.maybeCallback(callback);
-                } catch (e) {
-                    return tools.maybeCallbackWithError(callback, e);
-                }
+        for (const i in keys) {
+            const id = keys[i];
+            const meta = metas[i];
+            meta.acl.permissions = options.mode;
+            try {
+                await this.client.set(id, JSON.stringify(meta));
+            } catch (e) {
+                return tools.maybeCallbackWithError(callback, e);
             }
         }
+        return tools.maybeCallback(callback);
     }
 
     async _chmodFile(id, name, options, callback, meta) {
@@ -1853,9 +1852,9 @@ class ObjectsInRedisClient {
     }
 
     chmodFileAsync(id, name, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.chmodFile(id, name, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     enableFileCache(enabled, options, callback) {
@@ -1933,9 +1932,9 @@ class ObjectsInRedisClient {
     }
 
     subscribeAsync(pattern, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.subscribe(pattern, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     subscribeUser(pattern, options, callback) {
@@ -1953,9 +1952,9 @@ class ObjectsInRedisClient {
     }
 
     subscribeUserAsync(pattern, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.subscribeUser(pattern, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     _unsubscribe(pattern, options, subClient, callback) {
@@ -2003,9 +2002,9 @@ class ObjectsInRedisClient {
     }
 
     unsubscribeAsync(pattern, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.unsubscribe(pattern, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     unsubscribeUser(pattern, options, callback) {
@@ -2023,9 +2022,9 @@ class ObjectsInRedisClient {
     }
 
     unsubscribeUserAsync(pattern, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.unsubscribeUser(pattern, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     async _objectHelper(keys, objs, callback) {
@@ -2835,9 +2834,9 @@ class ObjectsInRedisClient {
     }
 
     delObjectAsync(id, options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.delObject(id, options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     // this function is very ineffective. Because reads all objects and then process them
@@ -3699,9 +3698,9 @@ class ObjectsInRedisClient {
     }
 
     destroyDBAsync(options) {
-        return new Promise((resolve, reject) =>
+        return /** @type {Promise<void>} */ (new Promise((resolve, reject) =>
             this.destroyDB(options, err =>
-                err ? reject(err) : resolve()));
+                err ? reject(err) : resolve())));
     }
 
     // Destructor of the class. Called by shutting down.

--- a/packages/db-objects-redis/lib/objects/objectsUtils.js
+++ b/packages/db-objects-redis/lib/objects/objectsUtils.js
@@ -687,7 +687,6 @@ module.exports = {
     sanitizePath,
     checkObject,
     checkObjectRights,
-    getLogger,
 
     regCheckId,
 

--- a/packages/db-objects-redis/lib/objects/objectsUtils.js
+++ b/packages/db-objects-redis/lib/objects/objectsUtils.js
@@ -643,25 +643,6 @@ function checkObjectRights(objects, id, object, options, flag, callback) {
     }
 }
 
-function getLogger(log) {
-    if (!log) {
-        log = {
-            silly: function (_msg) {/*console.log(msg);*/},
-            debug: function (_msg) {/*console.log(msg);*/},
-            info:  function (_msg) {/*console.log(msg);*/},
-            warn:  function (msg) {
-                console.log(msg);
-            },
-            error: function (msg) {
-                console.log(msg);
-            }
-        };
-    } else if (!log.silly) {
-        log.silly = log.debug;
-    }
-    return log;
-}
-
 // For objects
 const defaultAcl = {
     groups: [],

--- a/packages/db-objects-redis/lib/objects/objectsUtils.js
+++ b/packages/db-objects-redis/lib/objects/objectsUtils.js
@@ -476,7 +476,7 @@ function getUserGroup(objects, user, callback) {
     });
 }
 
-function sanitizePath(id, name, callback) {
+function sanitizePath(id, name) {
     if (!name) {
         name = '';
     }
@@ -485,7 +485,7 @@ function sanitizePath(id, name, callback) {
     }
 
     if (!id) {
-        return tools.maybeCallbackWithError(callback, 'Empty ID');
+        throw new Error('Empty ID');
     }
 
     id = id.replace(/[\][*,;'"`<>\\?/]/g, ''); // remove all invalid characters from states plus slashes

--- a/packages/db-states-file/index.js
+++ b/packages/db-states-file/index.js
@@ -1,6 +1,6 @@
 module.exports = {
     Client: require('@iobroker/db-states-redis').Client,
-    Server: require('./lib/states/statesInMemServerRedis.js'),
+    Server: require('./lib/states/statesInMemServerClass.js'),
     getDefaultObjectsPort: _host => {
         return 9000;
     }

--- a/packages/db-states-file/lib/states/statesInMemFileDB.js
+++ b/packages/db-states-file/lib/states/statesInMemFileDB.js
@@ -142,7 +142,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
 
     // needed by Server
     _getState(id) {
-        return this.dataset[id] !== undefined ? this.dataset[id] : null;
+        return this.dataset[id];
     }
 
     // needed by Server
@@ -230,7 +230,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
 
     // needed by Server
     _getSession(id) {
-        return this.session[id] !== undefined ? this.session[id] : null;
+        return this.session[id];
     }
 
     // internal functionality

--- a/packages/db-states-file/lib/states/statesInMemFileDB.js
+++ b/packages/db-states-file/lib/states/statesInMemFileDB.js
@@ -16,7 +16,6 @@
 
 const InMemoryFileDB        = require('@iobroker/db-base').inMemoryFileDB;
 const tools                 = require('@iobroker/db-base').tools;
-//const { isDeepStrictEqual } = require('util');
 
 // settings = {
 //    change:    function (id, state) {},
@@ -61,7 +60,6 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         this.stateExpires = {};
         this.sessionExpires = {};
         this.ONE_DAY_IN_SECS = 24*60*60*1000;
-        //this.adapterSubs = [];
         this.writeFileInterval = this.settings.connection && typeof this.settings.connection.writeFileInterval === 'number' ?
             parseInt(this.settings.connection.writeFileInterval) : 30000;
         this.log.silly(`${this.namespace} States DB uses file write interval of ${this.writeFileInterval} ms`);
@@ -156,133 +154,6 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         typeof callback === 'function' && setImmediate(state => callback(null, state), this.dataset[id] !== undefined ? this.dataset[id] : null);
     }
 
-    /*/**
-     * Promise-version of getState
-     */
-    /*getStateAsync(id) {
-        return new Promise((resolve, reject) => {
-            this.getState(id, (err, res) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(res);
-                }
-            });
-        });
-    }
-*/
-    /*
-    /**
-     * @method setState
-     * @param id {String}           the id of the value.
-     * @param state {any}
-     *
-     *
-     *      an object containing the actual value and some metadata:<br>
-     *      setState(id, {'val': val, 'ts': ts, 'ack': ack, 'from': from, 'lc': lc, 'user': system.user.NAME})
-     *
-     *      if no object is given state is treated as val:<br>
-     *      setState(id, val)
-     *
-     *      <ul><li><b>val</b>  the actual value. Can be any JSON-stringifiable object. If undefined the
-     *                          value is kept unchanged.</li>
-     *
-     *      <li><b>ack</b>  a boolean that can be used to mark a value as confirmed, used in bidirectional systems which
-     *                      acknowledge that a value has been successfully set. Will be set to false if undefined.</li>
-     *
-     *      <li><b>ts</b>   a unix timestamp indicating the last write-operation on the state. Will be set by the
-     *                      setState method if undefined.</li>
-     *
-     *      <li><b>lc</b>   a unix timestamp indicating the last change of the actual value. this should be undefined
-     *                      when calling setState, it will be set by the setValue method itself.</li></ul>
-     *
-     * @param callback {Function}   will be called when redis confirmed reception of the command
-     */
-    /*setState(id, state, callback) {
-        const obj = {};
-
-        if (typeof state !== 'object' || state === null) {
-            state = {
-                val: state
-            };
-        }
-
-        let oldObj = this.dataset[id];
-
-        if (!oldObj) {
-            oldObj = {val: null};
-        }
-
-        if (state.val !== undefined) {
-            obj.val = state.val;
-        } else {
-            obj.val = oldObj.val;
-        }
-
-        if (state.ack !== undefined) {
-            obj.ack = state.ack === null ? oldObj.ack || false : state.ack;
-        } else {
-            obj.ack = false;
-        }
-
-        if (state.ts !== undefined) {
-            obj.ts = (state.ts < 946681200000) ? state.ts * 1000 : state.ts; // if less 2000.01.01 00:00:00
-        } else {
-            obj.ts = Date.now();
-        }
-
-        if (state.q !== undefined) {
-            obj.q = state.q;
-        } else {
-            obj.q = 0;
-        }
-
-        // comment
-        if (state.c && typeof state.c === 'string') {
-            obj.c = state.c.substring(0, 512);
-        }
-
-        if (state.ms !== undefined) {
-            obj.ms = state.ms;
-        }
-
-        obj.from = state.from;
-
-        if (state.user !== undefined) {
-            obj.user = state.user;
-        }
-
-        let hasChanged;
-
-        if (state.lc !== undefined) {
-            obj.lc = state.lc;
-        } else {
-            // isDeepStrictEqual works on objects and primitive values
-            hasChanged = !isDeepStrictEqual(oldObj.val, obj.val);
-            if (!oldObj.lc || hasChanged) {
-                obj.lc = obj.ts;
-            } else {
-                obj.lc = oldObj.lc;
-            }
-        }
-        this._setStateDirect(id, obj, state.expire, callback);
-    }
-*/
-    /*/**
-     * Promise-version of setState
-     */
-    /*setStateAsync(id, state) {
-        return new Promise((resolve, reject) => {
-            this.setState(id, state, (err, res) => {
-                if (err) {
-                    reject(err);
-                } else {
-                    resolve(res);
-                }
-            });
-        });
-    }
-*/
     // needed by Server
     _setStateDirect(id, obj, expire, callback) {
         if (typeof expire === 'function') {
@@ -317,16 +188,6 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         }
     }
 
-    /*
-    setRawState(id, state, callback) {
-        this.dataset[id] = state;
-        typeof callback === 'function' && setImmediate(() => callback(null, id));
-
-        if (!this.stateTimer) {
-            this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
-        }
-    }
-*/
     // needed by Server
     delState(id, callback) {
         if (this.stateExpires[id]) {
@@ -365,187 +226,31 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         typeof callback === 'function' && setImmediate(() => callback(null, result));
     }
 
-    /*
-    subscribe(pattern, cb) {
-        this.subscribeForClient(this.callbackSubscriptionClient, pattern, cb);
-    }
-*/
     // needed by Server
     subscribeForClient(client, pattern, cb) {
         this.handleSubscribe(client, 'state', pattern, cb);
     }
-    /*
-    unsubscribe(pattern, cb) {
-        this.unsubscribeForClient(this.callbackSubscriptionClient, pattern, cb);
-    }
-*/
+
     // needed by Server
     unsubscribeForClient(client, pattern, cb) {
         this.handleUnsubscribe(client, 'state', pattern, cb);
     }
 
-    /*    /**
-     * Register some instance as subscribable.
-     * If some instance says, that it is subscribable, the instance can read every time (and at start)
-     * all subscriptions to their states and will receive messages about changes of subscriptions
-     *
-     * @param instance name of instance
-     * @param cb callback which says if subscription added or yet exists
-     */
-    /*    registerAdapterSubs(instance, cb) {
-        let added = false;
-        if (this.adapterSubs.indexOf(instance) === -1) {
-            this.adapterSubs.push(instance);
-            this.adapterSubs.sort();
-            added = true;
-        }
-        if (cb) {
-            cb(null, added);
-        }
-    }
-*/
-    /*    /**
-     * Unregister instance as subscribable.
-     *
-     * @param instance name of instance
-     * @param cb callback which says if subscription removed or no
-     */
-    /*    unregisterAdapterSubs(instance, cb) {
-        const pos = this.adapterSubs.indexOf(instance);
-        if (pos !== -1) {
-            this.adapterSubs.splice(pos, 1);
-        }
-        if (cb) {
-            cb(null, pos !== -1);
-        }
-    }
-*/
-    /*    pushMessage(id, state, callback) {
-        state._id = this.globalMessageId++;
-
-        if (this.globalMessageId >= 0xFFFFFFFF) {
-            this.globalMessageId = 0;
-        }
-
-        typeof callback === 'function' && setImmediate(() => callback(null, id));
-
-        setImmediate(() => this.publishAll('messagebox', 'messagebox.' + id, state));
-    }
-*/
-    /*    subscribeMessage(id, cb) {
-        this.subscribeMessageForClient(this.callbackSubscriptionClient, id, cb);
-    }
-*/
     // needed by Server
     subscribeMessageForClient(client, id, cb) {
         this.handleSubscribe(client, 'messagebox', 'messagebox.' + id, cb);
     }
 
-    /*    unsubscribeMessage(id, cb) {
-        this.unsubscribeMessageForClient(this.callbackSubscriptionClient, id, cb);
-    }
-*/
     // needed by Server
     unsubscribeMessageForClient(client, id, cb) {
         this.handleUnsubscribe(client, 'messagebox', 'messagebox.' + id, cb);
     }
 
-    /*    /**
-     * @method pushLog
-     * @param {String} id           the id of the logger.
-     * @param {object} log          log object, looks like
-     *      pushLog(id, {message: msg, severity: info|debug|warn|error, from: that.namespace, ts: Date.now()})
-     *
-     *      <ul><li><b>message</b>  the actual value. Can be any JSON-stringifiable object. If undefined the
-     *                          value is kept unchanged.</li>
-     *
-     *      <li><b>severity</b>  a boolean that can be used to mark a value as confirmed, used in bidirectional systems which
-     *                      acknowledge that a value has been successfully set. Will be set to false if undefined.</li>
-     *
-     *      <li><b>from</b>   a unix timestamp indicating the last write-operation on the state. Will be set by the
-     *                      setState method if undefined.</li>
-     *
-     *      <li><b>ts</b>   a unix timestamp indicating the last change of the actual value. this should be undefined
-     *                      when calling setState, it will be set by the setValue method itself.</li></ul>
-     *
-     * @param callback {Function}   will be called when confirmed reception of the command
-     */
-    /*    pushLog(id, log, callback) {
-        // do not store messages.
-        //logs[id] = logs[id] || [];
-        log._id = this.globalLogId++;
-        if (this.globalLogId >= 0xFFFFFFFF) {
-            this.globalLogId = 0;
-        }
-        //logs[id].unshift(state);
-        //if (logs[id].length > settings.connection.maxQueue) {
-        //    logs[id].splice(settings.connection.maxQueue - logs[id].length);
-        //}
-        typeof callback === 'function' && setImmediate(() => callback(null, id));
-
-        setImmediate(() => this.publishAll('log', 'log.' + id, log));
-    }
-
-    lenLog(id, callback) {
-        if (this.logs[id]) {
-            typeof callback === 'function' && setImmediate(logLen => callback(null, logLen, id), this.logs[id].length);
-        } else {
-            typeof callback === 'function' && setImmediate(() => callback(tools.ERRORS.ERROR_NOT_FOUND, null, id));
-        }
-    }
-
-    getLog(id, callback) {
-        if (this.logs[id]) {
-            typeof callback === 'function' && setImmediate((logEntry, logLen) => callback(null, logEntry, logLen), this.logs[id].pop(), this.logs[id].length);
-        } else {
-            typeof callback === 'function' && setImmediate(() => callback(tools.ERRORS.ERROR_NOT_FOUND, null, 0));
-        }
-    }
-
-    delLog(id, logId, callback) {
-        if (this.logs[id]) {
-            let found = false;
-            for (let i = this.logs[id].length - 1; i >= 0; i--) {
-                if (this.logs[id][i]._id === logId) {
-                    this.logs[id].splice(i, 1);
-                    found = true;
-                    break;
-                }
-            }
-            if (!found) {
-                // Protection against too much lost IDs
-                if (this.logs[id].length > 100) {
-                    console.log('WARNING: cannot find logs with id = ' + logId);
-                    this.log.error(this.namespace + ' WARNING: cannot find logs with id = ' + logId);
-                    this.logs[id].splice(100, this.logs[id].length - 100);
-                }
-                typeof callback === 'function' && setImmediate(() => callback(tools.ERRORS.ERROR_NOT_FOUND));
-            } else {
-                typeof callback === 'function' && setImmediate(() => callback());
-            }
-        } else if (typeof callback === 'function') {
-            setImmediate(() => callback(tools.ERRORS.ERROR_NOT_FOUND));
-        }
-    }
-
-    clearAllLogs(callback) {
-        this.logs = {};
-        typeof callback === 'function' && setImmediate(() => callback());
-    }
-
-    subscribeLog(id, cb) {
-        this.subscribeLogForClient(this.callbackSubscriptionClient, id, cb);
-    }
-*/
     // needed by Server
     subscribeLogForClient(client, id, cb) {
         this.handleSubscribe(client, 'log', 'log.' + id, cb);
     }
-    /*
-    unsubscribeLog(id, cb) {
-        this.unsubscribeLogForClient(this.callbackSubscriptionClient, id, cb);
-    }
-*/
+
     // needed by Server
     unsubscribeLogForClient(client, id, cb) {
         this.handleUnsubscribe(client, 'log', 'log.' + id, cb);
@@ -619,26 +324,6 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
             this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
         }
     }
-
-/*    getBinaryState(id, callback) {
-        if (this.dataset[id]) {
-            typeof callback === 'function' && setImmediate(state => callback(null, state), this.dataset[id]);
-        } else {
-            typeof callback === 'function' && setImmediate(() => callback('not exists'));
-        }
-    }
-
-    delBinaryState(id, callback) {
-        if (this.dataset[id]) {
-            delete this.dataset[id];
-        }
-        typeof callback === 'function' && setImmediate(() => callback(null, id));
-
-        if (!this.stateTimer) {
-            this.stateTimer = setTimeout(() => this.saveState(), this.writeFileInterval);
-        }
-    }
- */
 }
 
 module.exports = StatesInMemoryFileDB;

--- a/packages/db-states-file/lib/states/statesInMemFileDB.js
+++ b/packages/db-states-file/lib/states/statesInMemFileDB.js
@@ -61,7 +61,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         this.stateExpires = {};
         this.sessionExpires = {};
         this.ONE_DAY_IN_SECS = 24*60*60*1000;
-//        this.adapterSubs = [];
+        //this.adapterSubs = [];
         this.writeFileInterval = this.settings.connection && typeof this.settings.connection.writeFileInterval === 'number' ?
             parseInt(this.settings.connection.writeFileInterval) : 30000;
         this.log.silly(`${this.namespace} States DB uses file write interval of ${this.writeFileInterval} ms`);
@@ -156,10 +156,10 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         typeof callback === 'function' && setImmediate(state => callback(null, state), this.dataset[id] !== undefined ? this.dataset[id] : null);
     }
 
-/*    /**
+    /*/**
      * Promise-version of getState
      */
-/*    getStateAsync(id) {
+    /*getStateAsync(id) {
         return new Promise((resolve, reject) => {
             this.getState(id, (err, res) => {
                 if (err) {
@@ -198,7 +198,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
      *
      * @param callback {Function}   will be called when redis confirmed reception of the command
      */
-/*    setState(id, state, callback) {
+    /*setState(id, state, callback) {
         const obj = {};
 
         if (typeof state !== 'object' || state === null) {
@@ -268,10 +268,10 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         this._setStateDirect(id, obj, state.expire, callback);
     }
 */
-/*    /**
+    /*/**
      * Promise-version of setState
      */
-/*    setStateAsync(id, state) {
+    /*setStateAsync(id, state) {
         return new Promise((resolve, reject) => {
             this.setState(id, state, (err, res) => {
                 if (err) {
@@ -365,7 +365,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         typeof callback === 'function' && setImmediate(() => callback(null, result));
     }
 
-/*
+    /*
     subscribe(pattern, cb) {
         this.subscribeForClient(this.callbackSubscriptionClient, pattern, cb);
     }
@@ -374,7 +374,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
     subscribeForClient(client, pattern, cb) {
         this.handleSubscribe(client, 'state', pattern, cb);
     }
-/*
+    /*
     unsubscribe(pattern, cb) {
         this.unsubscribeForClient(this.callbackSubscriptionClient, pattern, cb);
     }
@@ -384,7 +384,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         this.handleUnsubscribe(client, 'state', pattern, cb);
     }
 
-/*    /**
+    /*    /**
      * Register some instance as subscribable.
      * If some instance says, that it is subscribable, the instance can read every time (and at start)
      * all subscriptions to their states and will receive messages about changes of subscriptions
@@ -392,7 +392,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
      * @param instance name of instance
      * @param cb callback which says if subscription added or yet exists
      */
-/*    registerAdapterSubs(instance, cb) {
+    /*    registerAdapterSubs(instance, cb) {
         let added = false;
         if (this.adapterSubs.indexOf(instance) === -1) {
             this.adapterSubs.push(instance);
@@ -404,13 +404,13 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         }
     }
 */
-/*    /**
+    /*    /**
      * Unregister instance as subscribable.
      *
      * @param instance name of instance
      * @param cb callback which says if subscription removed or no
      */
-/*    unregisterAdapterSubs(instance, cb) {
+    /*    unregisterAdapterSubs(instance, cb) {
         const pos = this.adapterSubs.indexOf(instance);
         if (pos !== -1) {
             this.adapterSubs.splice(pos, 1);
@@ -420,7 +420,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         }
     }
 */
-/*    pushMessage(id, state, callback) {
+    /*    pushMessage(id, state, callback) {
         state._id = this.globalMessageId++;
 
         if (this.globalMessageId >= 0xFFFFFFFF) {
@@ -432,7 +432,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         setImmediate(() => this.publishAll('messagebox', 'messagebox.' + id, state));
     }
 */
-/*    subscribeMessage(id, cb) {
+    /*    subscribeMessage(id, cb) {
         this.subscribeMessageForClient(this.callbackSubscriptionClient, id, cb);
     }
 */
@@ -441,7 +441,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         this.handleSubscribe(client, 'messagebox', 'messagebox.' + id, cb);
     }
 
-/*    unsubscribeMessage(id, cb) {
+    /*    unsubscribeMessage(id, cb) {
         this.unsubscribeMessageForClient(this.callbackSubscriptionClient, id, cb);
     }
 */
@@ -450,7 +450,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
         this.handleUnsubscribe(client, 'messagebox', 'messagebox.' + id, cb);
     }
 
-/*    /**
+    /*    /**
      * @method pushLog
      * @param {String} id           the id of the logger.
      * @param {object} log          log object, looks like
@@ -470,7 +470,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
      *
      * @param callback {Function}   will be called when confirmed reception of the command
      */
-/*    pushLog(id, log, callback) {
+    /*    pushLog(id, log, callback) {
         // do not store messages.
         //logs[id] = logs[id] || [];
         log._id = this.globalLogId++;
@@ -541,7 +541,7 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
     subscribeLogForClient(client, id, cb) {
         this.handleSubscribe(client, 'log', 'log.' + id, cb);
     }
-/*
+    /*
     unsubscribeLog(id, cb) {
         this.unsubscribeLogForClient(this.callbackSubscriptionClient, id, cb);
     }

--- a/packages/db-states-file/lib/states/statesInMemFileDB.js
+++ b/packages/db-states-file/lib/states/statesInMemFileDB.js
@@ -121,10 +121,10 @@ class StatesInMemoryFileDB extends InMemoryFileDB {
 
     // Destructor of the class. Called by shutting down.
     // internal functionality
-    destroy() {
+    async destroy() {
         this._expireAll();
 
-        super.destroy();
+        await super.destroy();
 
         if (this.stateTimer) {
             clearTimeout(this.stateTimer);

--- a/packages/db-states-file/lib/states/statesInMemServerClass.js
+++ b/packages/db-states-file/lib/states/statesInMemServerClass.js
@@ -1,0 +1,48 @@
+/**
+ *      States DB in memory - Server with Redis protocol
+ *
+ *      Copyright 2013-2020 bluefox <dogafox@gmail.com>
+ *
+ *      MIT License
+ *
+ */
+
+/** @module statesInMemory */
+
+/* jshint -W097 */
+/* jshint strict:false */
+/* jslint node: true */
+'use strict';
+
+const StatesInRedisClient = require('@iobroker/db-states-redis').Client;
+const StatesInMemServer = require('./statesInMemServerRedis');
+
+class StatesInMemoryServerClass extends StatesInRedisClient {
+
+    constructor(settings) {
+        settings.autoConnect = false; // delay Client connection to when we need it
+        super(settings);
+
+        const serverSettings = {
+            namespace:  settings.namespace + '-Server',
+            connection: settings.connection,
+            logger:     settings.logger,
+            hostname:   settings.hostname,
+            connected: () => {
+                this.connectDb(); // now that server is connected also connect client
+            },
+        }
+        this.statesServer = new StatesInMemServer(serverSettings);
+    }
+
+    async destroy() {
+        await super.destroy(); // destroy client first
+        this.statesServer.destroy(); // server afterwards too
+    }
+
+    getStatus() {
+        return this.statesServer.getStatus(); // return Status as Server
+    }
+}
+
+module.exports = StatesInMemoryServerClass;

--- a/packages/db-states-file/lib/states/statesInMemServerClass.js
+++ b/packages/db-states-file/lib/states/statesInMemServerClass.js
@@ -37,7 +37,7 @@ class StatesInMemoryServerClass extends StatesInRedisClient {
 
     async destroy() {
         await super.destroy(); // destroy client first
-        this.statesServer.destroy(); // server afterwards too
+        await this.statesServer.destroy(); // server afterwards too
     }
 
     getStatus() {

--- a/packages/db-states-file/lib/states/statesInMemServerClass.js
+++ b/packages/db-states-file/lib/states/statesInMemServerClass.js
@@ -30,8 +30,8 @@ class StatesInMemoryServerClass extends StatesInRedisClient {
             hostname:   settings.hostname,
             connected: () => {
                 this.connectDb(); // now that server is connected also connect client
-            },
-        }
+            }
+        };
         this.statesServer = new StatesInMemServer(serverSettings);
     }
 

--- a/packages/db-states-file/lib/states/statesInMemServerRedis.js
+++ b/packages/db-states-file/lib/states/statesInMemServerRedis.js
@@ -61,7 +61,7 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
         this.namespaceMsgLen     = this.namespaceMsg.length;
         this.namespaceLogLen     = this.namespaceLog.length;
         //this.namespaceSessionlen = this.namespaceSession.length;
-        this._initRedisServer(this.settings.connection, (e) => {
+        this._initRedisServer(this.settings.connection, e => {
             if (e) {
                 this.log.error(this.namespace + ' Cannot start inMem-states on port ' + (this.settings.port || 9000) + ': ' + e.message);
                 process.exit(24); // todo: replace it with exitcode

--- a/packages/db-states-file/lib/states/statesInMemServerRedis.js
+++ b/packages/db-states-file/lib/states/statesInMemServerRedis.js
@@ -193,9 +193,9 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
             const {id, namespace} = this._normalizeId(data);
 
             if (namespace === this.namespaceStates) {
-                this.getStates(id, (err, result) => {
+                this._getStates(id, (err, result) => {
                     if (err || !result) {
-                        handler && handler.sendError(responseId, new Error('ERROR getStates: ' + err));
+                        handler && handler.sendError(responseId, new Error('ERROR _getStates: ' + err));
                         return;
                     }
                     for (let i = 0; i < result.length; i++) {
@@ -212,7 +212,7 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
         handler.on('get', (data, responseId) => {
             const {id, namespace} = this._normalizeId(data[0]);
             if (namespace === this.namespaceStates) {
-                this.getState(id, (err, result) => {
+                this._getState(id, (err, result) => {
                     if (err || !result) {
                         handler && handler.sendNull(responseId);
                     } else {
@@ -224,7 +224,7 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
                     }
                 });
             } else if (namespace === this.namespaceSession) {
-                this.getSession(id, result => {
+                this._getSession(id, result => {
                     if (!result) {
                         handler && handler.sendNull(responseId);
                     } else {
@@ -245,7 +245,7 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
                     try {
                         state = JSON.parse(data[1].toString('utf-8'));
                     } catch (e) { // No JSON, so handle as binary data and set as Buffer
-                        this.setBinaryState(id, data[1], (err, id) => {
+                        this._setBinaryState(id, data[1], (err, id) => {
                             if (err || !id) {
                                 handler && handler.sendError(responseId, new Error('ERROR setState id=' + id + ': ' + err));
                             } else {
@@ -303,11 +303,11 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
                         handler.sendError(responseId, new Error('ERROR parsing expire value ' + data[1].toString('utf-8')));
                         return;
                     }
-                    this.setSession(id, expire, state, () => {
+                    this._setSession(id, expire, state, () => {
                         handler && handler.sendString(responseId, 'OK');
                     });
                 } catch (err) {
-                    handler.sendError(responseId, new Error('ERROR setSession ' + id + ': ' + err));
+                    handler.sendError(responseId, new Error('ERROR _setSession ' + id + ': ' + err));
                 }
             } else {
                 handler.sendError(responseId, new Error('SETEX-UNSUPPORTED for namespace ' + namespace + ': Data=' + JSON.stringify(data)));
@@ -318,15 +318,15 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
         handler.on('del', (data, responseId) => {
             const {id, namespace} = this._normalizeId(data[0]);
             if (namespace === this.namespaceStates) {
-                this.delState(id, err => {
+                this._delState(id, err => {
                     if (err) {
-                        handler && handler.sendError(responseId, new Error('ERROR delState ' + id + ': ' + err));
+                        handler && handler.sendError(responseId, new Error('ERROR _delState ' + id + ': ' + err));
                     } else {
                         handler && handler.sendInteger(responseId, 1);
                     }
                 });
             } else if (namespace === this.namespaceSession) {
-                this.destroySession(id, () => {
+                this._destroySession(id, () => {
                     handler && handler.sendInteger(responseId, 1);
                 });
             } else {
@@ -342,9 +342,9 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
             }
             const {id, namespace} = this._normalizeId(data[0]);
             if (namespace === this.namespaceStates) {
-                this.getKeys(id, (err, result) => {
+                this._getKeys(id, (err, result) => {
                     if (err || !result) {
-                        handler && handler.sendError(responseId, new Error('ERROR getKeys: ' + err));
+                        handler && handler.sendError(responseId, new Error('ERROR _getKeys: ' + err));
                         return;
                     }
                     for (let i = 0; i < result.length; i++) {
@@ -361,13 +361,13 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
         handler.on('psubscribe', (data, responseId) => {
             const {id, namespace} = this._normalizeId(data[0]);
             if (namespace === this.namespaceMsg) {
-                this.subscribeMessageForClient(handler, id.substr(this.namespaceMsgLen), () =>
+                this._subscribeMessageForClient(handler, id.substr(this.namespaceMsgLen), () =>
                     handler && handler.sendArray(responseId, ['psubscribe', data[0], 1]));
             } else if (namespace === this.namespaceLog) {
-                this.subscribeLogForClient(handler, id.substr(this.namespaceLogLen), () =>
+                this._subscribeLogForClient(handler, id.substr(this.namespaceLogLen), () =>
                     handler && handler.sendArray(responseId, ['psubscribe', data[0], 1]));
             } else if (namespace === this.namespaceStates) {
-                this.subscribeForClient(handler, id, () =>
+                this._subscribeForClient(handler, id, () =>
                     handler && handler.sendArray(responseId, ['psubscribe', data[0], 1]));
             } else {
                 handler.sendError(responseId, new Error('PSUBSCRIBE-UNSUPPORTED for namespace ' + namespace + ': Data=' + JSON.stringify(data)));
@@ -378,13 +378,13 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
         handler.on('punsubscribe', (data, responseId) => {
             const {id, namespace} = this._normalizeId(data[0]);
             if (namespace === this.namespaceMsg) {
-                this.unsubscribeMessageForClient(handler, id.substr(this.namespaceMsgLen), () =>
+                this._unsubscribeMessageForClient(handler, id.substr(this.namespaceMsgLen), () =>
                     handler && handler.sendArray(responseId, ['punsubscribe', data[0], 1]));
             } else if (namespace === this.namespaceLog) {
-                this.unsubscribeLogForClient(handler, id.substr(this.namespaceLogLen), () =>
+                this._unsubscribeLogForClient(handler, id.substr(this.namespaceLogLen), () =>
                     handler && handler.sendArray(responseId, ['punsubscribe', data[0], 1]));
             } else if (namespace === this.namespaceStates) {
-                this.unsubscribeForClient(handler, id, () =>
+                this._unsubscribeForClient(handler, id, () =>
                     handler && handler.sendArray(responseId, ['punsubscribe', data[0], 1]));
             } else {
                 handler.sendError(responseId, new Error('PUNSUBSCRIBE-UNSUPPORTED for namespace ' + namespace + ': Data=' + JSON.stringify(data)));

--- a/packages/db-states-file/lib/states/statesInMemServerRedis.js
+++ b/packages/db-states-file/lib/states/statesInMemServerRedis.js
@@ -461,16 +461,17 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
      * Initialize Redis Server
      * @param settings Settings object
      * @private
+     * @return {Promise<void>}
      */
     _initRedisServer(settings) {
-        return /** @type {Promise<void|Error>} */ (new Promise((resolve, reject) => {
+        return new Promise((resolve, reject) => {
             if (settings.secure) {
                 reject(new Error('Secure Redis unsupported for File-DB'));
             }
             try {
                 this.server = net.createServer();
                 this.server.on('error', err =>
-                    this.log.info(this.namespace + ' ' + (settings.secure ? 'Secure ' : '') + ' Error inMem-states listening on port ' + (settings.port || 9000)) + ': ' + err);
+                    this.log.info(`${this.namespace} ${settings.secure ? 'Secure ' : ''} Error inMem-objects listening on port ${settings.port || 9001}: ${err}`));
                 this.server.on('connection', socket => this._initSocket(socket));
 
                 this.server.listen(
@@ -481,7 +482,7 @@ class StatesInMemoryServer extends StatesInMemoryFileDB {
             } catch (err) {
                 reject(err);
             }
-        }));
+        });
     }
 }
 

--- a/packages/db-states-redis/index.js
+++ b/packages/db-states-redis/index.js
@@ -1,5 +1,5 @@
 module.exports = {
-    Client: require('./lib/states/statesInRedis.js'),
+    Client: require('./lib/states/statesInRedisClient.js'),
     Server: null,
     getDefaultObjectsPort: host => {
         return (host.includes(',')) ? 26379 : 6379;

--- a/packages/db-states-redis/lib/states/statesInRedisClient.js
+++ b/packages/db-states-redis/lib/states/statesInRedisClient.js
@@ -47,25 +47,7 @@ class StateRedisClient {
         this.sub = null;
         this.subSystem = null;
 
-        this.log = this.settings.logger;
-        if (!this.log) {
-            this.log = {
-                silly: function (_msg) {/* console.log(msg); */
-                },
-                debug: function (_msg) {/* console.log(msg); */
-                },
-                info: function (_msg) {/* console.log(msg); */
-                },
-                warn: function (msg) {
-                    console.log(msg);
-                },
-                error: function (msg) {
-                    console.log(msg);
-                }
-            };
-        } else if (!this.log.silly) {
-            this.log.silly = this.log.debug;
-        }
+        this.log = tools.getLogger(this.settings.logger);
 
         if (this.settings.autoConnect === undefined || this.settings.autoConnect) {
             this.connectDb();

--- a/packages/db-states-redis/lib/states/statesInRedisClient.js
+++ b/packages/db-states-redis/lib/states/statesInRedisClient.js
@@ -49,7 +49,7 @@ class StateRedisClient {
 
         this.log = tools.getLogger(this.settings.logger);
 
-        if (this.settings.autoConnect === undefined || this.settings.autoConnect) {
+        if (this.settings.autoConnect !== false) {
             this.connectDb();
         }
     }


### PR DESCRIPTION
This PR does:
* reconstruct and simplify code so that the *InRedisClient classes handle all real requests and servers only provide backend logic
* Add a new Server class which is returned to the users of the library as server that combines a server but uses the client to do all communication
* "Break" all Server method naming to indicate private methods and make code break that somehow uses unwanted ways
* Fix a bug in chmod with multiple entries that only processed the first entry
* remove cloning of objects because now in server no longer needed
* enhance server that connected callback is called once the server is really listening and simplify rest of code (leftovers from socket.io deprecation)
* enhance client classes to allow a delayed connection to the server (default is still auto connection)
* cleanup and simplification of code
* basis for https://github.com/ioBroker/ioBroker.js-controller/issues/583

This is still for sure not 100% cleaning up server code from unneeded logic but a good start. All the rest needs to be checked very careful!