### PR TITLE
Map Redis Client Connection Closed error to ERROR_DB_CLOSED to handle the same in not rejecting

### DIFF
--- a/packages/db-base/lib/tools.js
+++ b/packages/db-base/lib/tools.js
@@ -62,4 +62,4 @@ module.exports.maybeCallbackWithRedisError = (callback, error, ...args) => {
         error.message = module.exports.ERRORS.ERROR_DB_CLOSED;
     }
     return module.exports.maybeCallbackWithError(callback, error, ...args);
-}
+};

--- a/packages/db-base/lib/tools.js
+++ b/packages/db-base/lib/tools.js
@@ -47,3 +47,19 @@ const controllerDir = getControllerDir() || __dirname;
 
 module.exports = require(path.join(controllerDir , 'lib/tools.js'));
 module.exports.getControllerDir = () => controllerDir;
+
+/**
+ * Checks if the given callback is a function and if so calls it with the given error and parameter immediately, else a resolved or rejected Promise is returned. Redis-Error "Connection is closed." is converted into ERROR_DB_CLOSED
+ *
+ * @param {((error: Error | null | undefined, ...args: any[]) => void) | null | undefined} callback - callback function to be executed
+ * @param {Error | string | null | undefined} error - error which will be used by the callback function. If callback is not a function and
+ * error is given, a rejected Promise is returned. If error is given but it is not an instance of Error, it is converted into one.
+ * @param {any[]} args - as many arguments as needed, which will be returned by the callback function or by the Promise
+ * @returns {Promise<any>} - if Promise is resolved with multiple arguments, an array is returned
+ */
+module.exports.maybeCallbackWithRedisError = (callback, error, ...args) => {
+    if (error && error instanceof Error && error.message.includes('Connection is closed')) {
+        error.message = module.exports.ERRORS.ERROR_DB_CLOSED;
+    }
+    return module.exports.maybeCallbackWithError(callback, error, ...args);
+}

--- a/packages/db-base/lib/tools.js
+++ b/packages/db-base/lib/tools.js
@@ -58,7 +58,7 @@ module.exports.getControllerDir = () => controllerDir;
  * @returns {Promise<any>} - if Promise is resolved with multiple arguments, an array is returned
  */
 module.exports.maybeCallbackWithRedisError = (callback, error, ...args) => {
-    if (error && error instanceof Error && error.message.includes('Connection is closed')) {
+    if (error instanceof Error && error.message.includes('Connection is closed')) {
         error.message = module.exports.ERRORS.ERROR_DB_CLOSED;
     }
     return module.exports.maybeCallbackWithError(callback, error, ...args);

--- a/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
+++ b/packages/db-objects-redis/lib/objects/objectsInRedisClient.js
@@ -472,7 +472,7 @@ class ObjectsInRedisClient {
             await this.client.set(id, data);
             return tools.maybeCallback(callback);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -493,7 +493,7 @@ class ObjectsInRedisClient {
             const data = await this.client.getBuffer(id);
             return tools.maybeCallbackWithError(callback, null, data);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -513,7 +513,7 @@ class ObjectsInRedisClient {
                 await this.client.del(id);
                 return tools.maybeCallback(callback);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
         }
     }
@@ -645,7 +645,7 @@ class ObjectsInRedisClient {
                 await this.client.set(metaID, JSON.stringify(meta));
                 return tools.maybeCallback(callback);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
         } else {
             if (!meta) {
@@ -675,7 +675,7 @@ class ObjectsInRedisClient {
                     await this.client.set(metaID, JSON.stringify(meta));
                     return tools.maybeCallbackWithError(callback, err);
                 } catch (e) {
-                    return tools.maybeCallbackWithError(callback, err || e);
+                    return tools.maybeCallbackWithRedisError(callback, err || e);
                 }
             });
         }
@@ -879,7 +879,7 @@ class ObjectsInRedisClient {
                 await this.client.del(metaID);
                 return tools.maybeCallback(callback);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
         }
     }
@@ -940,7 +940,7 @@ class ObjectsInRedisClient {
             try {
                 keys = await this._getKeysViaScan(dirID);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
 
             if (!this.client) {
@@ -972,7 +972,7 @@ class ObjectsInRedisClient {
         try {
             keys = await this._getKeysViaScan(dirID);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
 
         if (!this.client) {
@@ -1020,7 +1020,7 @@ class ObjectsInRedisClient {
         try {
             objs = await this.client.mget(keys);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
 
         const result = [];
@@ -1137,7 +1137,7 @@ class ObjectsInRedisClient {
                     }
                     await this.client.rename(id, id.replace(oldBase, newBase));
                 } catch (e) {
-                    return tools.maybeCallbackWithError(callback, e);
+                    return tools.maybeCallbackWithRedisError(callback, e);
                 }
             }
             return tools.maybeCallback(callback);
@@ -1175,7 +1175,7 @@ class ObjectsInRedisClient {
             try {
                 keys = await this._getKeysViaScan(dirID);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
 
             if (!this.client) {
@@ -1197,7 +1197,7 @@ class ObjectsInRedisClient {
             try {
                 objs = await this.client.mget(keys);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
             let result;
             const dontCheck =
@@ -1229,7 +1229,7 @@ class ObjectsInRedisClient {
                 await this.client.rename(oldMetaID, newMetaID);
                 return tools.maybeCallback(callback);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
         }
     }
@@ -1291,7 +1291,7 @@ class ObjectsInRedisClient {
             await this.client.set(metaID, JSON.stringify(meta));
             return tools.maybeCallback(callback);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -1340,7 +1340,7 @@ class ObjectsInRedisClient {
                     await this._delBinaryState(id.replace(/\$%\$meta$/, '$%$data'));
                     await this.client.del(id);
                 } catch (e) {
-                    return tools.maybeCallbackWithError(callback, e);
+                    return tools.maybeCallbackWithRedisError(callback, e);
                 }
             }
             return tools.maybeCallback(callback);
@@ -1369,7 +1369,7 @@ class ObjectsInRedisClient {
             try {
                 keys = await this._getKeysViaScan(dirID);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
             if (!this.client) {
                 return tools.maybeCallbackWithError(callback, utils.ERRORS.ERROR_DB_CLOSED);
@@ -1514,7 +1514,7 @@ class ObjectsInRedisClient {
             try {
                 await this.client.set(id, JSON.stringify(meta));
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
         }
         return tools.maybeCallback(callback);
@@ -1537,7 +1537,7 @@ class ObjectsInRedisClient {
             try {
                 await this.client.set(metaID, JSON.stringify(meta));
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
             const nameArr = name.split('/');
             const file = nameArr.pop();
@@ -1565,7 +1565,7 @@ class ObjectsInRedisClient {
         try {
             keys = await this._getKeysViaScan(dirID);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
 
         if (!this.client) {
@@ -1584,7 +1584,7 @@ class ObjectsInRedisClient {
         try {
             metas = await this.client.mget(keys);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
         const dontCheck = options.user === utils.CONSTS.SYSTEM_ADMIN_USER ||
                     options.group !== utils.CONSTS.SYSTEM_ADMIN_GROUP ||
@@ -1706,7 +1706,7 @@ class ObjectsInRedisClient {
             try {
                 await this.client.set(id, JSON.stringify(meta));
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
         }
         return tools.maybeCallback(callback);
@@ -1727,7 +1727,7 @@ class ObjectsInRedisClient {
             try {
                 await this.client.set(metaID, JSON.stringify(meta));
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
 
             const nameArr = name.split('/');
@@ -1756,7 +1756,7 @@ class ObjectsInRedisClient {
         try {
             keys = await this._getKeysViaScan(dirID);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
 
         if (!this.client) {
@@ -1775,7 +1775,7 @@ class ObjectsInRedisClient {
         try {
             objs = await this.client.mget(keys);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
 
         const dontCheck =
@@ -2052,7 +2052,7 @@ class ObjectsInRedisClient {
                     await this.client.set(id, message);
                     await this.client.publish(id, message);
                 } catch (e) {
-                    return tools.maybeCallbackWithError(callback, e);
+                    return tools.maybeCallbackWithRedisError(callback, e);
                 }
             }
             return tools.maybeCallback(callback);
@@ -2072,7 +2072,7 @@ class ObjectsInRedisClient {
             try {
                 objects = await this.client.mget(keys);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
             const filteredKeys = [];
             const filteredObjs = [];
@@ -2177,7 +2177,7 @@ class ObjectsInRedisClient {
             try {
                 objects = await this.client.mget(keys);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
 
             const filteredKeys = [];
@@ -2338,7 +2338,7 @@ class ObjectsInRedisClient {
         try {
             keys = await this._getKeysViaScan(this.objNamespace + pattern);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
 
         if (!this.client) {
@@ -2372,7 +2372,7 @@ class ObjectsInRedisClient {
                 try {
                     metas = await this.client.mget(keys);
                 } catch (e) {
-                    return tools.maybeCallbackWithError(callback, e);
+                    return tools.maybeCallbackWithRedisError(callback, e);
                 }
                 metas = metas || [];
                 for (let i = 0; i < keys.length; i++) {
@@ -2540,7 +2540,7 @@ class ObjectsInRedisClient {
         try {
             keys = await this._getKeysViaScan(this.objNamespace + pattern);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
         if (!this.client) {
             return tools.maybeCallbackWithError(callback, utils.ERRORS.ERROR_DB_CLOSED);
@@ -2605,7 +2605,7 @@ class ObjectsInRedisClient {
         try {
             oldObj = await this.client.get(this.objNamespace + id);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
 
         try {
@@ -2731,7 +2731,7 @@ class ObjectsInRedisClient {
 
             return tools.maybeCallbackWithError(callback, null, {id});
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e, {id});
+            return tools.maybeCallbackWithRedisError(callback, e, {id});
         }
     }
 
@@ -2816,7 +2816,7 @@ class ObjectsInRedisClient {
                 await this.client.publish(this.objNamespace + id, 'null');
                 return tools.maybeCallback(callback);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
         }
     }
@@ -3140,7 +3140,7 @@ class ObjectsInRedisClient {
             try {
                 keys = await this._getKeysViaScan(searchKeys);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
 
             if (!this.client) {
@@ -3259,7 +3259,7 @@ class ObjectsInRedisClient {
             obj = await this.client.get(this.objNamespace + '_design/' + design);
         } catch (e) {
             this.log.error(`${this.namespace} Cannot find view "${design}" for search "${search}" : ${e}`);
-            return tools.maybeCallbackWithError(callback, new Error(`Cannot find view "${design}"`));
+            return tools.maybeCallbackWithRedisError(callback, new Error(`Cannot find view "${design}"`));
         }
 
         if (obj) {
@@ -3329,7 +3329,7 @@ class ObjectsInRedisClient {
         try {
             keys = await this._getKeysViaScan(pattern);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
 
         if (!this.client) {
@@ -3427,7 +3427,7 @@ class ObjectsInRedisClient {
         try {
             oldObj = await this.client.get(this.objNamespace + id);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
 
         try {
@@ -3521,7 +3521,7 @@ class ObjectsInRedisClient {
             await this.client.publish(this.objNamespace + id, message);
             return tools.maybeCallbackWithError(callback, null, {id: id, value: oldObj}, id);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -3582,7 +3582,7 @@ class ObjectsInRedisClient {
                     try {
                         objs = await this.client.mget(keys);
                     } catch (e) {
-                        return tools.maybeCallbackWithError(callback, e);
+                        return tools.maybeCallbackWithRedisError(callback, e);
                     }
                     objs = objs || [];
                     // Assume it is name
@@ -3683,7 +3683,7 @@ class ObjectsInRedisClient {
                 const keys = await this._getKeysViaScan(`${this.redisNamespace}*`);
                 return this._destroyDBHelper(keys, callback);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
         }
     }

--- a/packages/db-states-redis/lib/states/statesInRedisClient.js
+++ b/packages/db-states-redis/lib/states/statesInRedisClient.js
@@ -476,7 +476,7 @@ class StateRedisClient {
             oldObj = await this.client.get(this.namespaceRedis + id);
         } catch (e) {
             this.log.warn(this.namespace + ' get state ' + e);
-            return tools.maybeCallbackWithError(callback, e, id);
+            return tools.maybeCallbackWithRedisError(callback, e, id);
         }
         if (!this.client) {
             return;
@@ -553,7 +553,7 @@ class StateRedisClient {
                 await this.client.publish(this.namespaceRedis + id, objString);
                 return tools.maybeCallbackWithError(callback, null, id);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e, id);
+                return tools.maybeCallbackWithRedisError(callback, e, id);
             }
         } else {
             try {
@@ -563,7 +563,7 @@ class StateRedisClient {
                 await this.client.publish(this.namespaceRedis + id, objString);
                 return tools.maybeCallbackWithError(callback, null, id);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e, id);
+                return tools.maybeCallbackWithRedisError(callback, e, id);
             }
         }
     }
@@ -597,7 +597,7 @@ class StateRedisClient {
             await this.client.set(this.namespaceRedis + id, JSON.stringify(state));
             return tools.maybeCallbackWithError(callback, null, id);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e, id);
+            return tools.maybeCallbackWithRedisError(callback, e, id);
         }
     }
 
@@ -781,7 +781,7 @@ class StateRedisClient {
             return tools.maybeCallbackWithError(callback, null, id);
         } catch (e) {
             this.log.warn(`${this.namespace} redis del ${id}, error - ${e}`);
-            return tools.maybeCallbackWithError(callback, e, id);
+            return tools.maybeCallbackWithRedisError(callback, e, id);
         }
     }
 
@@ -794,7 +794,7 @@ class StateRedisClient {
         try {
             obj = await this.client.keys(this.namespaceRedis + pattern);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
         this.settings.connection.enhancedLogging && this.log.silly(this.namespace + ' redis keys ' + obj.length + ' ' + pattern);
         if (obj && !dontModify) {
@@ -833,7 +833,7 @@ class StateRedisClient {
             subClient.ioBrokerSubscriptions[this.namespaceRedis + pattern] = new RegExp(tools.pattern2RegEx(this.namespaceRedis + pattern));
             return tools.maybeCallback(callback);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -898,7 +898,7 @@ class StateRedisClient {
             await this.client.publish(this.namespaceMsg + id, JSON.stringify(state));
             return tools.maybeCallbackWithError(callback, null, id);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -920,7 +920,7 @@ class StateRedisClient {
             this.subSystem.ioBrokerSubscriptions[this.namespaceMsg + id] = true;
             return tools.maybeCallback(callback);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -944,7 +944,7 @@ class StateRedisClient {
             }
             return tools.maybeCallback(callback);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -963,7 +963,7 @@ class StateRedisClient {
                 await this.client.publish(this.namespaceLog + id, JSON.stringify(log));
                 return tools.maybeCallbackWithError(callback, null, id);
             } catch (e) {
-                return tools.maybeCallbackWithError(callback, e);
+                return tools.maybeCallbackWithRedisError(callback, e);
             }
         }
     }
@@ -1012,7 +1012,7 @@ class StateRedisClient {
             this.subSystem.ioBrokerSubscriptions[this.namespaceLog + id] = true;
             return tools.maybeCallback(callback);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -1033,7 +1033,7 @@ class StateRedisClient {
             }
             return tools.maybeCallback(callback);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -1077,7 +1077,7 @@ class StateRedisClient {
             this.settings.connection.enhancedLogging && this.log.silly(`${this.namespace} redis setex`, id, expire, obj);
             return tools.maybeCallback(callback);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -1096,7 +1096,7 @@ class StateRedisClient {
             await this.client.del(id);
             return tools.maybeCallback(callback);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -1117,7 +1117,7 @@ class StateRedisClient {
             await this.client.set(this.namespaceRedis + id, data);
             return tools.maybeCallback(callback);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -1135,7 +1135,7 @@ class StateRedisClient {
             data = await this.client.getBuffer(this.namespaceRedis + id);
             return tools.maybeCallbackWithError(callback, null, data);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e);
+            return tools.maybeCallbackWithRedisError(callback, e);
         }
     }
 
@@ -1152,7 +1152,7 @@ class StateRedisClient {
             await this.client.del(this.namespaceRedis + id);
             return tools.maybeCallbackWithError(callback, null, id);
         } catch (e) {
-            return tools.maybeCallbackWithError(callback, e, id);
+            return tools.maybeCallbackWithRedisError(callback, e, id);
         }
     }
 }


### PR DESCRIPTION
For this we also could add manual logging or generic one in the new RedisError method? is that bringing a benefit?